### PR TITLE
[격리] 앵커와 검색 경로의 에이전트 범위 일관화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,11 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=your_redis_password
 REDIS_DB=0
+# Redis session 저장 실패 시 요청도 실패시킴 (기본 false: in-memory fallback)
+# MEMENTO_REDIS_SESSION_FAIL_CLOSED=false
+# 전환 릴리즈 기본 true: legacy agentId 사용 시 경고와 mcp_legacy_unbound_agent_scope_total 기록
+# 클라이언트 이관 후 false로 설정하면 strict 모드. includePeerAgents는 항상 master 전용.
+# MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE=true
 CACHE_ENABLED=true
 CACHE_DB_TTL=300
 # CACHE_SESSION_TTL=3600  # 기본값: SESSION_TTL_MINUTES와 동일

--- a/.env.example.minimal
+++ b/.env.example.minimal
@@ -25,6 +25,9 @@ DATABASE_URL=postgresql://postgres:change-me@localhost:5432/memento
 
 # Redis
 REDIS_ENABLED=false
+# MEMENTO_REDIS_SESSION_FAIL_CLOSED=false
+# 기본 true: legacy agentId 사용 경고/계수. 클라이언트 이관 후 false로 strict 모드 적용.
+# MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE=true
 CACHE_ENABLED=false
 
 # Context anchors (optional; defaults to total=20, reserve=10)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       # 단위시험은 --experimental-test-module-mocks에 의존하며 이 기능은 Node 24에서만
       # 안정적이다. 여기서는 런타임이 선언한 지원 범위에서 실제로 뜨는지만 본다.
       - name: Module graph loads
-        run: node -e "import('./lib/tools/index.js').then(m => { if (m.getToolsDefinition(null).length < 18) process.exit(1); })"
+        run: node -e "import('./lib/tools/index.js').then(m => { if (m.getToolsDefinition(null, true).length < 18) process.exit(1); })"
       - name: Startup gate rejects missing key
         run: |
           set +e

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@
 ### Added
 
 - 자동 앵커 승격만 비활성화할 수 있는 `MEMENTO_AUTO_PROMOTE_ANCHORS` 설정을 추가했다. 기본값과 빈 값은 기존 동작을 유지하는 `true`이며, 비활성 상태는 정리 결과·로그·`mcp_anchor_auto_promotion_enabled` 메트릭에서 확인할 수 있다.
+- `anchor-scope` CLI: non-default anchor를 shared/private/unconfirmed로 inventory한다. `--include-non-anchors`는 legacy 일반 파편까지 포함한다. 기본 dry-run이며 migration-047 schema guard와 명시 승인 목록을 통과한 shared 항목만 version history를 남기고 `default`로 정규화한다.
+- `MEMENTO_REDIS_SESSION_FAIL_CLOSED=true`: Redis session 저장 실패 시 요청도 실패시키는 opt-in. 기본값은 false이며 Redis 순단 시 in-memory 세션으로 계속 동작한다. 단, rotation에서 기존 Redis 세션 삭제가 실패하면 fixation 방지를 위해 항상 실패한다.
+- 검색 이벤트에 effective agent scope와 peer flag를 기록하는 migration-047.
 
 ### Changed
 
+- `fragment_history`와 `graph_explore`의 ID 기반 조회에도 workspace 필터를 적용한다. 종전의 ID만 지정한 조회와 호환되지 않을 수 있다. `default_workspace` 없는 키가 `workspace="proj"`에 저장한 파편의 이력은 `{ "id": "fragment-id", "workspace": "proj" }`로 조회해야 한다(`graph_explore`는 `id` 대신 `startId`). master는 `allWorkspaces=true`로 workspace 필터만 제거할 수 있으며 agent·key-group 범위는 유지된다.
+- `memory://stats`와 `memory://topics`는 현재 유효한(`valid_to IS NULL`) `default` agent 파편을 해당 리소스의 key/workspace 범위에서 집계한다. 리소스에는 peer 범위를 지정하는 통로가 없어 master도 이 리소스로 전체 agent 집계를 얻을 수 없다.
+- `search_traces`와 `reconstruct_history`에도 agent 필터를 적용한다. `agentId` 생략은 `default` 범위이므로 기존 관리 호출의 결과가 줄어들 수 있다. master는 특정 `agentId` 또는 `includePeerAgents=true`를 명시할 수 있다.
+- `searchBySource`를 사용하는 session-context와 learning 파편은 자기 키뿐 아니라 같은 키 그룹의 파편도 조회한다. 다른 읽기 경로와 같은 그룹 공유 계약이며 agent/workspace 제한은 유지된다.
 - 검색·캐시·그래프·컨텍스트의 기존 주 점수 의미는 유지하면서 동점 결과를 `created_at DESC, id ASC`로 결정적으로 정렬한다. 기존 내림차순 인덱스와 offset cursor 계약은 유지하며, ANN 검색은 인덱스가 고른 후보 집합 안에서만 동점을 정렬한다.
 - context anchor 기본 상한을 10개에서 20개로 변경한다. effective workspace에 기본 10개를 예약하면서도 나머지 10개를 잔여 workspace/global 통합 순위에 남기기 위한 의도적인 주입량 변경이다. Anchor는 `tokenBudget` 절삭 대상이 아니므로 최악 주입량이 종전의 2배가 될 수 있으며, 기존 주입량이 필요한 배포는 `MEMENTO_CONTEXT_ANCHOR_LIMIT=10`으로 유지할 수 있다. Reserve를 따로 지정하지 않으면 total/2를 내림한 값(최대 10)으로 유도해 total만 낮춘 기존 배포의 기동 실패와 workspace 예약분의 자동 독점을 피한다.
 - `recall.isAnchor`의 true/false/미지정 계약을 캐시·그래프·링크·케이스 확장까지 일관되게 적용한다. 검색 진입점과 링크 조회의 null도 미지정으로 정규화한다. case event 타임라인은 source 파편의 현재 앵커 상태와 분리해 과거 이력을 보존한다. `caseMode.fragment_count`는 키 그룹·workspace·유효 상태·앵커 필터를 적용한 대표 후보 수로 정의한다.
@@ -16,13 +23,28 @@
 
 ### Security
 
-- `recall`/`context`가 workspace와 key default를 모두 생략한 경우 이제 전역(`workspace IS NULL`) 파편만 조회한다. 전체 workspace 조회는 master가 `allWorkspaces=true`를 명시한 경우에만 허용하며, 일반 API key 요청은 권한 오류로 거부한다. anchor/core/learning/working memory와 L1~L3·graph·linked hydration에도 같은 계약을 적용한다.
+- 기억 조회가 workspace와 key default를 모두 생략한 경우 이제 전역(`workspace IS NULL`) 파편만 조회한다. 전체 workspace 조회는 master가 `allWorkspaces=true`를 명시한 경우에만 허용하며, 일반 API key 요청은 권한 오류로 거부한다. recall/context의 anchor/core/learning/working memory와 L1~L3·graph·linked hydration뿐 아니라 reconstruct_history/search_traces에도 같은 계약을 적용한다.
+- `context`의 anchor/core/learning/Working Memory와 recall의 source/linked/graph/semantic hydration에 동일한 agent 범위를 적용한다. `agentId` 생략은 `default` 공유 기억만, 지정 시 해당 agent와 `default`만 반환한다.
+- `includePeerAgents=true`는 master key 전용으로 제한한다. 일반 API key 요청은 권한 오류로 거부하며 key-group/workspace 경계는 완화하지 않는다.
+- API key에는 아직 non-default agent identity 바인딩이 없다. 이번 전환 릴리즈는 `MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE=true`를 기본으로 기존 클라이언트의 non-default `agentId` 주장을 허용하고, 실제 완화 경로 사용에 경고 로그와 `mcp_legacy_unbound_agent_scope_total` 계수기를 남긴다. `false`를 명시하면 일반 API key는 생략/`default`만 허용한다. `includePeerAgents`는 설정과 무관하게 master 전용이다.
+- transport session context가 없는 직접 `tools/call` dispatch와 body의 내부 권한 필드 위조를 fail-closed로 거부한다.
+- migration-047은 version/case-event scope 컬럼을 nullable로만 추가한다. 구버전 writer와의 롤링 호환을 위해 `NOT NULL` 제약과 대량 backfill을 migration 트랜잭션에 포함하지 않는다.
+- agent scope snapshot 진단은 `anchor-scope --backfill-snapshots`로 제공한다. source가 남은 legacy snapshot만 짧은 배치로 복구하며, source가 없거나 삭제된 행은 NULL 격리 상태로 남고 peer 조회에서도 제외된다. 완료 판정과 출력은 `sourceMissing`/`sourceDeleted` 잔량을 함께 드러내어 복구 가능한 행 처리와 격리 데이터 잔존을 구분한다.
+- 일반 API key에서 `memory_stats`를 포함한 master 전용 도구는 tools/list와 OpenAPI 모두에서 노출하지 않는다. 기존 read 권한 키의 도구 목록에서 `memory_stats`가 제거된다.
+- 기존 데이터는 `anchor-scope --include-non-anchors`로 inventory한 뒤 명시적으로 공유 분류된 항목만 `default`로 이관한다. 정규화는 파편과 해당 `fragment_versions.agent_id`를 같은 트랜잭션에서 옮겨 변경 이력의 가시성을 유지한다. 기본 활성인 legacy 호환 모드는 같은 key 내부 agent 인증을 보장하지 않으므로 사용 계수를 관찰하고 클라이언트 이관 후 명시적으로 `false`로 전환한다. 다음 부 버전의 기본 차단 전환은 사용 계수가 0인지 확인한 뒤 판단한다.
+- 인과 체인 링크는 양 끝 파편이 모두 요청의 agent/key/effective-workspace 범위 안에 있을 때만 반환한다. workspace 생략 시 전역(NULL), 지정 시 해당 workspace와 전역, master의 `allWorkspaces=true`일 때만 전체 workspace를 허용한다.
 
 ### 업그레이드 주의
 
+- 업그레이드 전에 열린 세션은 재연결하여 `initialize`를 다시 수행해야 한다. `isMaster` 없는 구 세션이 bearer 인증정보 없이 재사용되면 재앵커링할 수 없어 도구 호출이 `-32001`로 실패한다.
+- migration-047은 `fragment_versions`와 `case_events`의 legacy snapshot을 자동으로 채우지 않는다. `migrate`의 잔량 경고를 확인하고 구 writer 종료 후 `anchor-scope --backfill-snapshots --execute --approve-backfill`을 수동 실행한다. 그 전에는 NULL snapshot 이력·이벤트가 읽기에서 제외되어 `fragment_history.versions`가 비어 보일 수 있다.
+- snapshot 롤백은 컬럼과 backfill 결과를 삭제하며 `anchor-scope --execute` 정규화를 되돌리지 않는다. 재적용·재백필은 현재 파편의 `default`를 기록하므로 정규화 이전 agent 복원에는 별도 사전 백업이 필요하다.
+- `anchor-scope` 출력은 항상 JSON이다. `--json`은 기존 호출 호환용이며 출력 형식을 바꾸지 않는다.
+- `MCP_REJECT_NONAPIKEY_OAUTH=false`는 non-API-key OAuth 인증을 허용하지만 master 권한을 부여하지 않는다. 도구 호출에는 API 키 바인딩이 필요하며, 바인딩 없는 OAuth 세션은 `-32001`로 거부된다.
+- snapshot backfill은 실행당 최대 1,000배치로 제한한다. 상한 도달 시 처리 건수와 함께 실패 종료하며, 이미 커밋된 배치는 유지된다. 구 writer 종료를 확인한 뒤 같은 명령으로 남은 항목을 이어서 처리할 수 있다.
 - master 키로 workspace를 생략해 전체 기억을 조회하던 관리 호출은 `allWorkspaces=true`를 추가해야 한다. 명시 workspace와 API key `default_workspace`의 의미는 유지된다.
 - `default_workspace`가 없는 공유 키로 저장할 때 workspace를 명시해 왔다면, `recall`과 `context`에도 같은 workspace를 명시해야 한다. 생략하면 이제 전역(`workspace IS NULL`) 범위만 조회하며, 빈 결과 힌트는 workspace를 지정한 재검색을 안내한다.
-- 업그레이드 전에 Redis Working Memory에 들어간 항목은 workspace 필드가 없어 scoped/global-only context에서 안전하게 판정할 수 없으므로 제외된다. master의 `allWorkspaces=true`에서는 조회할 수 있으며, 그 밖에는 해당 WM 목록이 만료·퇴출·삭제될 때까지 남을 수 있다(명목 TTL 24시간, 쓰기 시 갱신).
+- 업그레이드 전에 Redis Working Memory에 들어간 항목은 workspace 필드가 없어 scoped/global-only context에서 안전하게 판정할 수 없으므로 제외된다. master의 `allWorkspaces=true`에서는 agent/key 메타데이터가 확인되는 항목만 조회할 수 있고, agent/key 메타데이터도 없으면 항상 제외된다. 그 밖에는 해당 WM 목록이 만료·퇴출·삭제될 때까지 남을 수 있다(명목 TTL 24시간, 쓰기 시 갱신).
 
 ### Fixed
 

--- a/README.en.md
+++ b/README.en.md
@@ -167,7 +167,7 @@ See [integration guides](docs/getting-started/) for platform-specific setup.
 |---------|-------------|
 | `remember` | Decomposes important information into atomic fragments and stores them. With `MEMENTO_REMEMBER_ATOMIC=true`, the quota check and the INSERT run as a single atomic transaction. |
 | `recall` | Returns only relevant memories via keyword + semantic 3-tier search. `SearchScope` consistently applies workspace/caseId/affect and other scope filters across all L1-L3 layers. |
-| `context` | Automatically restores key context at session start |
+| `context` | Restores key context. `agentId=X` returns `X + default`; omission returns shared `default` memory only. |
 | Auto-cleanup | Duplicate merging, contradiction detection, importance decay, TTL-based forgetting |
 | Storage adapter layer | `lib/storage/` holds the storage abstraction. The `getStorage()` factory returns `PgVectorStore` (default) or `SqliteVecStore` (stub, not yet implemented) based on the `MEMENTO_STORAGE` environment variable. |
 | **Link Reconsolidation** | `tool_feedback` signals update fragment_links weight/confidence in real time (ReconsolidationEngine). Contradicting links are automatically quarantined. |
@@ -185,6 +185,18 @@ See [integration guides](docs/getting-started/) for platform-specific setup.
 | Migration lint | `npm run lint:migrations` checks new migration files for numbering conflicts and convention violations before commit. |
 
 See [SKILL.md](SKILL.md) for the full list of MCP tools.
+
+### Agent scope
+
+`agent_id='default'` is shared within the same key/workspace; any other value selects that agent's scope. Omit `agentId` or use `default` for ordinary clients. API keys have no trusted specific-agent binding; strict mode restricts specific-agent selection to master authentication. `includePeerAgents=true` always requires master authentication and never widens key/workspace boundaries. Before normalizing legacy anchors, run `memento-mcp anchor-scope --classifications <file>` (dry-run by default). Add `--include-non-anchors` to inventory all legacy fragments. Execution requires migration-047 plus the bare `--execute --approve-shared` flags.
+
+This transition release defaults `MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE` to `true`, allowing deployed clients' non-default `agentId` claims. Each compatibility use emits a warning and increments `mcp_legacy_unbound_agent_scope_total`. This does not authenticate agents sharing an API key. Migrate clients, confirm the counter stops increasing, then explicitly set `false` for strict mode. A default change in the next minor release requires first confirming zero compatibility usage.
+
+For upgrades, apply migration-047 (nullable columns), roll the new code to every instance and confirm all old writers have stopped, inspect counts with `memento-mcp anchor-scope --backfill-snapshots`, then run `--backfill-snapshots --execute --approve-backfill`. Both `fragment_versions` and `case_events` require manual backfill; `migrate` warns about pending snapshots. Until then, NULL snapshots are excluded and existing version histories may appear empty. Missing/deleted-source rows remain quarantined as NULL, excluded even from peer reads. Remaining or quarantined rows cause `SNAPSHOT_BACKFILL_INCOMPLETE` with `sourceMissing`/`sourceDeleted` counts. Quarantined rows require operator review; rerunning alone cannot repair them.
+
+Reconnect old sessions and run `initialize` again. Old sessions reused without bearer credentials may fail with `-32001` because their explicit authentication scope cannot be restored. Normalization moves fragment and version snapshot agents in one transaction. Rolling back the snapshot migration drops columns and backfill results but does not undo normalization; reapplying/backfilling uses the current agent. Keep a separate pre-execution backup if restoration is required.
+
+Backfill is limited to 1,000 batches per invocation. `--batch-size` accepts integers from 1 to 10,000 (default 500). Reaching the limit fails with committed progress counts. Progress is retained, so confirm old writers have stopped and rerun the same command to process remaining NULL snapshots.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Claude.ai Web / ChatGPT 연동은 OAuth를 사용한다. 발급한 API 키(`mmcp
 |------|------|
 | `remember` | 중요한 정보를 원자적 파편으로 분해하여 저장. `MEMENTO_REMEMBER_ATOMIC=true` 시 quota check + INSERT를 단일 트랜잭션으로 원자화. |
 | `recall` | 키워드 + 시맨틱 3계층 검색으로 필요한 기억만 반환. `SearchScope`가 workspace/caseId/affect 등 scope를 L1~L3 전 레이어에 정합 적용. |
-| `context` | 세션 시작 시 핵심 맥락을 자동 복원 |
+| `context` | 세션 시작 시 핵심 맥락을 자동 복원. `agentId=X`는 `X + default`, 생략 시 `default` 공유 기억만 반환. |
 | 자동 정리 | 중복 병합, 모순 탐지, 중요도 감쇠, TTL 기반 망각 |
 | storage 어댑터 계층 | `lib/storage/`에 스토리지 추상화 계층이 있다. `getStorage()` 팩토리가 `MEMENTO_STORAGE` ENV에 따라 `PgVectorStore`(기본) 또는 `SqliteVecStore`(스텁, 미구현)를 반환한다. |
 | 링크 재통합 | `tool_feedback` 피드백이 fragment_links의 weight/confidence에 실시간 반영 (ReconsolidationEngine). 모순 링크는 자동 격리(quarantine). |
@@ -184,6 +184,20 @@ Claude.ai Web / ChatGPT 연동은 OAuth를 사용한다. 발급한 API 키(`mmcp
 | 마이그레이션 lint | `npm run lint:migrations`로 신규 마이그레이션 파일의 번호 충돌·규약 위반을 커밋 전 자동 검사. |
 
 전체 MCP 도구 목록은 [SKILL.md](SKILL.md) 참조.
+
+### Agent 범위
+
+`agent_id='default'`는 같은 key/workspace의 공유 기억이고, 다른 값은 해당 agent 범위의 기억이다. `agentId` 생략은 공유 기억만 조회한다. 일반 클라이언트에는 `agentId` 생략 또는 `default`를 권장한다. API key에는 신뢰 가능한 agent identity 바인딩이 없으며, strict 모드에서는 specific agent를 master만 지정할 수 있다. `includePeerAgents=true`는 항상 master 전용이고 key/workspace 경계를 넓히지 않는다.
+
+기존 non-default anchor를 공유 범위로 옮기기 전에는 `memento-mcp anchor-scope --classifications <file>`로 dry-run inventory를 확인한다. 비앵커 일반 파편까지 이관 대상이면 `--include-non-anchors`를 추가한다. 실제 변경은 migration-047 적용 후 승인 JSON의 `shared` 목록과 `--execute --approve-shared`를 모두 명시해야 한다. `private`와 `unconfirmed` 항목은 변경하지 않는다.
+
+이번 전환 릴리즈의 `MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE` 기본값은 `true`다. non-default `agentId`를 사용하던 클라이언트를 유예하며 실제 사용마다 경고 로그와 `mcp_legacy_unbound_agent_scope_total`을 기록한다. 이 모드는 같은 API key를 공유하는 agent 사이를 인증할 수 없다. 클라이언트를 이관하고 계수가 더 이상 증가하지 않는지 확인한 뒤 `false`를 명시해 strict 모드로 전환한다. 다음 부 버전의 기본 차단은 사용 계수 0을 확인한 뒤 판단한다.
+
+업그레이드는 migration-047(nullable 컬럼 추가) → 모든 인스턴스의 새 코드 롤링 배포 및 구 writer 종료 확인 → `memento-mcp anchor-scope --backfill-snapshots` 사전 집계 → `--backfill-snapshots --execute --approve-backfill` 순서로 진행한다. `fragment_versions`와 `case_events` 모두 수동 backfill이 필요하며 `migrate`는 잔량을 경고한다. 그 전에는 NULL snapshot이 조회에서 제외되어 기존 변경 이력이 비어 보일 수 있다. source가 없거나 삭제된 행은 peer에서도 제외되는 NULL 격리 상태로 남는다. 잔여·격리 행이 있으면 `SNAPSHOT_BACKFILL_INCOMPLETE`로 실패하고 `sourceMissing`/`sourceDeleted` 건수를 보고한다. 격리 행은 단순 재실행으로 복구되지 않으므로 관리자가 검토해야 한다.
+
+구 세션은 재연결하여 `initialize`를 다시 수행한다. bearer 없는 구 세션은 명시적 인증 범위를 복원하지 못해 `-32001`로 실패할 수 있다. 정규화는 파편과 version snapshot agent를 같은 트랜잭션에서 옮긴다. snapshot migration 롤백은 컬럼과 backfill 결과를 지우지만 정규화를 되돌리지 않으며, 재백필은 현재 agent 값을 사용한다. 원상 복구가 필요하면 실행 전 별도 백업을 보관한다.
+
+backfill은 실행당 최대 1,000배치이며 `--batch-size`는 1~10,000 정수만 허용한다(기본 500). 상한에 도달하면 커밋된 처리 건수를 포함한 오류로 종료한다. 기존 진행은 보존되므로 구 writer가 종료됐는지 확인한 뒤 같은 명령을 다시 실행해 남은 NULL snapshot을 처리한다.
 
 ## CLI
 
@@ -344,7 +358,7 @@ docs/
 
 ## 알려진 제한사항
 
-- L1 Redis 캐시는 API 키 기반 격리만 지원한다. multi-agent 환경에서 에이전트 간 격리는 L2/L3에서 적용된다.
+- L1 Redis 인덱스는 API 키 단위지만, Hot Cache/Working Memory hydration에서 effective agent 범위를 재검증한다. agent metadata가 없는 구형 캐시 항목은 fail-closed로 제외된다.
 - 자동 품질 평가는 decision, preference, relation 유형만 대상이다. fact, procedure, error는 평가 큐에서 제외된다.
 - MEMENTO_ACCESS_KEY를 설정하지 않으면 서버가 기동하지 않는다. 인증 없이 운용하려면 MEMENTO_AUTH_DISABLED=true를 함께 명시해야 한다.
 - ALLOWED_ORIGINS — 브라우저 기반 MCP 클라이언트 화이트리스트. 미설정 시 모든 Origin을 허용한다.

--- a/SKILL.md
+++ b/SKILL.md
@@ -718,7 +718,6 @@ curl -s -X POST $SERVER_URL \
   -H "Authorization: Bearer $ACCESS_KEY" \
   -H "MCP-Session-Id: $SESSION_ID" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"reflect","arguments":{
-    "agentId":"AGENT_ID",
     "summary":["요약 내용1","요약 내용2"],
     "decisions":["기술/아키텍처 결정사항"],
     "errors_resolved":["원인: X → 해결: Y"]
@@ -730,7 +729,6 @@ curl -s -X POST $SERVER_URL \
   -H "Authorization: Bearer $ACCESS_KEY" \
   -H "MCP-Session-Id: $SESSION_ID" \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"remember","arguments":{
-    "agentId":"AGENT_ID",
     "content":"저장할 내용",
     "topic":"주제",
     "type":"fact",
@@ -744,7 +742,6 @@ curl -s -X POST $SERVER_URL \
   -H "Authorization: Bearer $ACCESS_KEY" \
   -H "MCP-Session-Id: $SESSION_ID" \
   -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"recall","arguments":{
-    "agentId":"AGENT_ID",
     "text":"검색어",
     "keywords":["키워드"]
   }}}'
@@ -755,7 +752,6 @@ curl -s -X POST $SERVER_URL \
   -H "Authorization: Bearer $ACCESS_KEY" \
   -H "MCP-Session-Id: $SESSION_ID" \
   -d '{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"context","arguments":{
-    "agentId":"AGENT_ID",
     "structured":true
   }}}'
 ```
@@ -800,7 +796,7 @@ curl 응답 검증 체크:
 
 1. 같은 API 키 또는 같은 키 그룹 + 동일 workspace를 사용한다. 파편 공유 범위는 키 그룹 단위다.
 2. 공동 작업은 동일 caseId를 공유하고, 진행 파편은 즉시 remember한다(기본 scope=permanent — 저장 즉시 상대 에이전트가 recall로 조회 가능). scope=session 파편은 세션 전용 스크래치라 공유되지 않는다.
-3. agentId 정책을 통일한다(default 또는 팀 고정 ID). 에이전트마다 다른 agentId를 쓰면 recall의 agent 필터 때문에 상대 파편이 검색에서 제외된다.
+3. 공동 기억은 `agentId`를 생략하거나 `default`로 통일한다. 일반 API key의 팀 고정 ID는 신뢰 가능한 agent 인증이 아니다. 전환 릴리즈의 legacy 호환 기본값은 true지만 이관 후 `MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE=false`로 차단하며, specific agent 관리와 peer 조회는 master 권한을 사용한다.
 4. 중간 가설은 assertionStatus="inferred"로 저장하고, 검증한 에이전트가 amend로 verified/rejected 전환한다. 미검증 가설과 확정 사실을 섞지 않는 것이 협업 오염 방지의 핵심이다.
 5. 상대 에이전트의 파편이 유용했으면 tool_feedback(relevant=true)을 보낸다 — 링크 가중치 강화가 팀 검색 품질을 누적 개선한다.
 6. 전체 흐름 복기는 reconstruct_history(caseId) 또는 recall(caseMode=true). 모순 발견 시 link(relationType="contradicts") 명시 후 대표 파편을 amend로 정리한다.
@@ -888,7 +884,7 @@ async 사용 지침: 대량(수십~200건) 일괄 저장에서 호출자 대기�
 | linkRelationType | string | - | 연결 관계 필터 (related, caused_by, resolved_by, part_of, contradicts) |
 | threshold | number | - | similarity 임계값 0~1 |
 | includeSuperseded | boolean | - | 만료 파편 포함. 기본 false. |
-| includePeerAgents | boolean | - | true 시 같은 키/workspace 스코프 내 다른 agentId 파편 포함 (멀티에이전트 협업용). 키·workspace 경계는 유지. 기본 false. |
+| includePeerAgents | boolean | - | master 전용. 같은 키/workspace 범위의 다른 agent 파편 포함. 일반 API 키는 권한 오류. 기본 false. |
 | includeKeyName | boolean | X | true 시 각 파편에 key_id·key_name(액세스 키 라벨) 포함. 같은 키 그룹 스코프의 정보만 노출. 팀 공유 workspace에서 파편 생성 주체 식별용. 기본 false |
 | asOf | string | - | ISO 8601. 해당 시점에 가까운 파편을 상위로 올리는 시간 근접 랭킹 기준(anchorTime)으로만 작동. 주의: 그 시점에 유효했던 버전을 복원하는 bitemporal as-of 필터가 아니며, 과거 시점 스냅샷 조회는 미구현. 특정 기간의 파편을 실제로 한정하려면 timeRange를 쓴다. |
 | timeRange | object | - | {from, to} 생성시각(created_at) 기준 시간창 필터. ISO 8601과 한국어 자연어("3일 전","지난 주","오늘") 모두 지원. 지정 시 시간 검색 경로가 동작하고 RRF에서 시간 근접 가중이 부스트된다. |
@@ -1029,7 +1025,7 @@ fragment_ids를 지정하고 ENABLE_RECONSOLIDATION=true인 경우: relevant=fal
 
 ### memory_stats
 
-기억 시스템 통계. 파라미터 없음.
+기억 시스템 전역 통계. master key 전용, 파라미터 없음.
 
 ### memory_consolidate
 
@@ -1047,6 +1043,9 @@ fragment_ids를 지정하고 ENABLE_RECONSOLIDATION=true인 경우: relevant=fal
 |------|------|------|------|
 | startId | string | O | 시작 파편 ID (error 권장) |
 | agentId | string | - | 에이전트 ID |
+| includePeerAgents | boolean | - | master 전용. 같은 key/workspace 범위의 다른 agent 노드 포함. 기본 false. |
+| workspace | string | - | 생략 시 key 기본값, 둘 다 없으면 전역(NULL) 범위. 시작·이웃 파편에 함께 적용. |
+| allWorkspaces | boolean | - | master 전용. workspace 필터를 제거하고 agent/key 범위는 유지. 기본 false. |
 
 startId가 타 테넌트 소유 파편인 경우 `"Fragment not found or no permission"` 오류가 반환된다.
 
@@ -1058,7 +1057,9 @@ startId가 타 테넌트 소유 파편인 경우 `"Fragment not found or no perm
 |------|------|------|------|
 | id | string | O | 조회할 파편 ID |
 | agentId | string | - | 에이전트 ID |
-| includePeerAgents | boolean | - | true 시 같은 API 키 스코프 내 다른 agentId의 파편 이력도 조회. 테넌트(키) 경계는 유지. 기본 false |
+| includePeerAgents | boolean | - | master 전용. 같은 key/workspace 범위의 다른 agent 이력 포함. 일반 API 키는 권한 오류. 기본 false. |
+| workspace | string | - | 생략 시 key 기본값, 둘 다 없으면 전역(NULL) 범위. 현재 파편·버전·superseded chain에 함께 적용. |
+| allWorkspaces | boolean | - | master 전용. workspace 필터를 제거하고 agent/key 범위는 유지. 기본 false. |
 
 id가 타 테넌트 소유 파편인 경우 `"Fragment not found or no permission"` 오류가 반환된다.
 
@@ -1086,6 +1087,9 @@ id가 타 테넌트 소유 파편인 경우 `"Fragment not found or no permissio
 | query | string | - | content 키워드 추가 필터 |
 | limit | number | 100 | 최대 반환 파편 수 (최대 500) |
 | workspace | string | - | 워크스페이스 필터 |
+| allWorkspaces | boolean | false | master 전용. true이면 timeline·event·evidence·인과 링크의 workspace 필터를 제거 |
+| agentId | string | default | 특정 agent 지정은 master 전용 |
+| includePeerAgents | boolean | false | master 전용. 같은 key/workspace 범위의 모든 agent 포함 |
 
 반환값:
 - `ordered_timeline`: 시간순 파편 배열 (각 항목에 agent_id 포함 — 멀티에이전트 케이스에서 기여 에이전트 식별용)
@@ -1116,6 +1120,9 @@ id가 타 테넌트 소유 파편인 경우 `"Fragment not found or no permissio
 | session_id | string | - | 특정 세션 필터 |
 | time_range | object | - | { from: ISO8601, to: ISO8601 } |
 | workspace | string | - | 워크스페이스 필터. 지정 시 해당 workspace + 전역(NULL) 파편만 대상 |
+| allWorkspaces | boolean | false | master 전용. true이면 trace의 workspace 필터를 제거 |
+| agentId | string | default | 특정 agent 지정은 master 전용 |
+| includePeerAgents | boolean | false | master 전용. 같은 key/workspace 범위의 모든 agent 포함 |
 | limit | number | 20 | 최대 반환 수 (최대 100) |
 
 snake_case 파라미터에는 camelCase alias가 있다: `eventType`, `entityKey`, `caseId`, `sessionId`. 두 표기 중 어느 쪽을 보내도 동일하게 처리된다.
@@ -1131,7 +1138,7 @@ snake_case 파라미터에는 camelCase alias가 있다: `eventType`, `entityKey
 
 **목적**: 현재 세션을 종료하고 새 `sessionId`를 발급한다. 토큰 탈취 의심 시 또는 주기적 로테이션에 사용한다.
 
-**언제 사용**: 키 노출이 의심되거나 스케줄된 회전 시점에서 동일 `bound_key_id` / `workspace` / `permissions`로 새 세션을 발급받을 때.
+**언제 사용**: 키 노출이 의심되거나 스케줄된 회전 시점에서 credential의 `bound_key_id` / key group / `permissions`를 재검증하고, 기존 세션의 `defaultWorkspace` / `mode`를 유지한 새 세션을 발급받을 때.
 
 | 파라미터 | 타입 | 기본값 | 설명 |
 |---|---|---|---|

--- a/bin/memento.js
+++ b/bin/memento.js
@@ -33,10 +33,11 @@ const COMMANDS = {
   completion: () => import('../lib/cli/completion.js'),
   session:    () => import('../lib/cli/session.js'),
   benchmark:  () => import('../lib/cli/benchmark.js'),
+  'anchor-scope': () => import('../lib/cli/anchor-scope.js'),
 };
 
 /** 원격 모드를 지원하지 않는 로컬 전용 명령 목록 */
-const LOCAL_ONLY_COMMANDS = new Set(["serve", "migrate", "cleanup", "backfill", "health", "update", "export", "import", "benchmark"]);
+const LOCAL_ONLY_COMMANDS = new Set(["serve", "migrate", "cleanup", "backfill", "health", "update", "export", "import", "benchmark", "anchor-scope"]);
 
 /**
  * `memento-mcp --help` 출력 텍스트를 stdout으로 송출한다.
@@ -61,6 +62,7 @@ function printUsage() {
     '  completion <shell>               Print shell completion script (bash|zsh)',
     '  session <list|show|delete>       Manage active sessions (headless/CI)',
     '  benchmark [--goldset FILE]       Measure recall quality against a goldset',
+    '  anchor-scope [--execute]         Inventory/normalize approved shared anchors',
     '',
     'Options:',
     '  --help                      Show this help message',

--- a/docs/api-reference.en.md
+++ b/docs/api-reference.en.md
@@ -89,10 +89,10 @@ X-RateLimit-Resource: fragments
 
 All MCP tool calls must pass RBAC validation.
 
-- Master key (`MEMENTO_ACCESS_KEY`): treated as `permissions=null`, granting access to all tools.
+- Master key (`MEMENTO_ACCESS_KEY`): identified by explicit trusted `isMaster=true`, granting access to all tools. Neither `permissions=null` nor `keyId=null` alone implies master authentication.
 - API key (`mmcp_xxx`): tool access is restricted based on the `permissions` array specified at key creation time. Requests for tools not included in the array are immediately denied.
 - Tools registered in the `TOOL_PERMISSIONS` map require the corresponding permission level. Unregistered tool names are treated as `required=null` and pass the permission check. To bring a new tool into the RBAC boundary, register it explicitly in the `TOOL_PERMISSIONS` map.
-- Three permission levels exist: `read` (recall/context/memory_stats etc.), `write` (remember/forget/amend etc.), `admin` (memory_consolidate/apply_update etc.). A key with `admin` permission can invoke tools at all levels.
+- Three permission levels exist: `read` (recall/context etc.), `write` (remember/forget/amend etc.), and `admin` (memory_consolidate/apply_update etc.). The `admin` permission does not bypass tools that require explicit master authentication.
 - When a forget/amend/link request targets a fragment owned by another tenant (different API key), a `"Fragment not found"` error is returned. Isolation is enforced at the SQL level via `key_id` conditions, so the fragment's existence is never exposed.
 
 Accessing a protected resource without authentication returns `401 Unauthorized` with a `WWW-Authenticate: Bearer resource_metadata="</.well-known/oauth-protected-resource URL>"` header.
@@ -304,10 +304,16 @@ MCP resources for real-time queries on the current state of the memory system.
 
 | URI | Description | Data Source |
 |-----|-------------|-------------|
-| `memory://stats` | System statistics | Per-type and per-tier counts and utility score averages from the `fragments` table |
-| `memory://topics` | Topic list | All unique `topic` labels from the `fragments` table |
+| `memory://stats` | Scoped statistics | Per-type/per-tier counts and utility averages for current default-agent fragments within the resource's key/workspace scope |
+| `memory://topics` | Scoped topic list | Unique topics from current default-agent fragments in the same scope |
 | `memory://config` | System configuration | Weights and TTL thresholds defined in `MEMORY_CONFIG` |
 | `memory://active-session` | Session activity log | Current session tool usage history recorded in `SessionActivityTracker` (Redis) |
+
+These resources have no `includePeerAgents` input, so even master cannot request all-agent aggregates through them. Superseded fragments (`valid_to IS NOT NULL`) are excluded.
+
+Omitting agentId selects default; specifying it selects that agent plus default. This transition release defaults `MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE=true`, allowing deployed API-key specific-agent claims with a warning and counter. Setting false enables strict mode, where specific-agent selection requires master authentication. `includePeerAgents` always requires master authentication regardless of the flag. `search_traces` and `reconstruct_history` also apply this default agent filter, so existing administrative calls may return fewer rows.
+
+ID lookups through `fragment_history` and `graph_explore` now apply workspace filters. For an ordinary key with no default_workspace that stored a fragment in proj, request its history with `{ "id": "fragment-id", "workspace": "proj" }`. Master may use `{ "id": "fragment-id", "allWorkspaces": true }` to remove only the workspace filter. For `graph_explore`, replace `id` with `startId` in both examples. Omitting workspace selects global-only, so previously successful ID-only calls may now return not found.
 
 ---
 
@@ -326,7 +332,7 @@ MCP resources for real-time queries on the current state of the memory system.
 | linkRelationType | string | - | Link relation type filter (related, caused_by, resolved_by, part_of, contradicts) |
 | threshold | number | - | Similarity threshold (0-1) |
 | includeSuperseded | boolean | - | Include expired (superseded) fragments. Default false. |
-| includePeerAgents | boolean | - | When true, includes fragments from other agentIds within the same key/workspace scope (for multi-agent collaboration). Key and workspace boundaries are preserved. Default false. |
+| includePeerAgents | boolean | - | Master only. Includes other agents within the same key/workspace scope. Ordinary API keys receive a permission error. Default false. |
 | includeKeyName | boolean | - | When true, each fragment carries key_id and key_name (the access key label). Only information within the same key group scope is exposed. Default false. |
 | asOf | string | - | ISO 8601. Return only fragments valid at the specified point in time. |
 | excludeSeen | boolean | - | Exclude fragments already injected by context(). Default true. |
@@ -851,7 +857,7 @@ Usefulness feedback on tool usage results. Evaluates whether the target tool's r
 
 ## MCP Tool — memory_stats
 
-Query fragment memory system statistics. Returns total fragment count, TTL distribution, and per-type statistics.
+Master-key-only fragment memory statistics. Returns total fragment count, TTL distribution, and per-type statistics. Because these are global aggregates without tenant scope, regular API keys cannot access this tool.
 
 ### Parameters
 
@@ -903,7 +909,7 @@ Execute fragment memory maintenance. Performs TTL transitions, importance decay,
 
 ## MCP Tool — session_rotate
 
-Closes the current session and issues a new `sessionId`. Use it when a token leak is suspected or on a rotation schedule. The same `bound_key_id`, `workspace`, and `permissions` carry over to the new session.
+Closes the current session and issues a new `sessionId`. Use it when a token leak is suspected or on a rotation schedule. Rotation revalidates the current credential and refreshes `bound_key_id`, key-group membership, and `permissions`, while preserving the `defaultWorkspace` and `mode` selected on the existing session.
 
 ### Parameters
 
@@ -923,6 +929,9 @@ Traces causal relationship chains starting from an error fragment. Dedicated to 
 |------|------|----------|-------------|
 | startId | string | Y | Starting fragment ID (error fragment recommended) |
 | agentId | string | - | Agent ID |
+| includePeerAgents | boolean | - | Master only. Includes other agents' nodes within the same key/workspace scope. Default false. |
+| workspace | string | - | Scope for the start fragment and neighbors. Falls back to the key default; global (NULL) only when neither is set. |
+| allWorkspaces | boolean | - | Master only. Removes workspace filters from the start fragment and neighbors, preserving agent/key boundaries. Default false. |
 
 ---
 
@@ -936,7 +945,9 @@ Query the complete change history of a fragment. Returns previous versions modif
 |------|------|----------|-------------|
 | id | string | Y | Fragment ID to query |
 | agentId | string | - | Agent ID |
-| includePeerAgents | boolean | - | When true, also returns version history for other agentIds within the same API key scope. The tenant (key) boundary is never relaxed. Default false. |
+| includePeerAgents | boolean | - | Master only. Includes other agents' history within the same key/workspace scope. Ordinary API keys receive a permission error. Default false. |
+| workspace | string | - | Scope for the current fragment, versions and superseded chain. Falls back to the key default; global (NULL) only when neither is set. |
+| allWorkspaces | boolean | - | Master only. Removes workspace filters from the current fragment, versions and superseded chain, preserving agent/key boundaries. Default false. |
 
 ---
 
@@ -966,6 +977,9 @@ Reconstruct work history chronologically based on case_id or entity. Restores na
 | query | string | - | Additional keyword filter |
 | limit | number | - | Default 100, max 500 |
 | workspace | string | - | Workspace filter. When specified, only fragments from the given workspace + global (NULL) fragments are targeted. |
+| allWorkspaces | boolean | - | Master only. When true, removes workspace filters from the timeline, events, evidence, and causal links. |
+| agentId | string | - | Defaults to shared default scope. Strict mode requires master for specific-agent selection; transition compatibility defaults true and temporarily accepts existing API-key claims. |
+| includePeerAgents | boolean | - | Master only. Includes all agents within the same key/workspace scope. Default false. |
 
 ### Returns
 
@@ -994,6 +1008,9 @@ Search fragments by exact matching (unlike recall's semantic search, uses conten
 | time_range | object | - | Time range filter. Includes from (start time, ISO 8601), to (end time, ISO 8601). |
 | limit | number | - | Default 20, max 100 |
 | workspace | string | - | Workspace filter. When specified, only fragments from the given workspace + global (NULL) fragments are targeted. |
+| allWorkspaces | boolean | - | Master only. When true, removes the workspace filter from traces. |
+| agentId | string | - | Defaults to shared default scope. Strict mode requires master for specific-agent selection; transition compatibility defaults true and temporarily accepts existing API-key claims. |
+| includePeerAgents | boolean | - | Master only. Includes all agents within the same key/workspace scope. Default false. |
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -93,10 +93,10 @@ X-RateLimit-Resource: fragments
 
 모든 MCP 도구 호출은 RBAC 검증을 통과해야 한다.
 
-- master key (`MEMENTO_ACCESS_KEY`): `permissions=null`로 처리되며 모든 도구를 호출할 수 있다.
+- master key (`MEMENTO_ACCESS_KEY`): 신뢰된 인증 결과의 명시적 `isMaster=true`로 판정하며 모든 도구를 호출할 수 있다. `permissions=null`이나 `keyId=null`만으로 master 권한을 추론하지 않는다.
 - API key (`mmcp_xxx`): 키 생성 시 지정된 `permissions` 배열 기준으로 도구 접근이 제한된다. 배열에 필요한 권한이 없으면 즉시 거부된다.
 - `TOOL_PERMISSIONS` 맵에 등록된 도구는 해당 권한 레벨이 요구된다. 맵에 등록되지 않은 도구명은 `required=null`로 간주되어 권한 검사를 통과한다. 도구를 RBAC 경계에 편입하려면 `TOOL_PERMISSIONS` 맵에 명시적으로 등록해야 한다.
-- 권한 레벨은 세 가지다: `read`(recall/context/memory_stats 등), `write`(remember/forget/amend 등), `admin`(memory_consolidate/apply_update 등). `admin` 권한을 가진 키는 모든 레벨을 호출할 수 있다.
+- 권한 레벨은 세 가지다: `read`(recall/context 등), `write`(remember/forget/amend 등), `admin`(memory_consolidate/apply_update 등). `admin` 권한만으로 master 전용 도구를 우회할 수는 없다.
 - 권한이 없는 도구를 호출하면 JSON-RPC 오류 `-32600`이 반환되며 `message`는 `Internal error`다. 거부 사유(`Permission denied: '<도구>' requires '<레벨>' permission`)는 서버 로그에만 남는다. 따라서 클라이언트는 응답만으로 권한 부족과 서버 오류를 구분할 수 없으므로, 재시도 정책을 세울 때 이 점을 감안해야 한다. `memory_consolidate`와 `apply_update`, `check_update`가 이 경로에 해당한다.
 - 타 테넌트(다른 API 키)가 소유한 파편에 forget/amend/link 요청 시 `"Fragment not found"` 에러가 반환된다. SQL 레벨에서 `key_id` 조건으로 격리되므로 존재 여부조차 노출되지 않는다.
 
@@ -309,10 +309,16 @@ API 키의 일일 호출 제한을 변경한다. 마스터 키 인증 필요.
 
 | URI | 설명 | 데이터 소스 |
 |-----|------|------------|
-| `memory://stats` | 시스템 통계 | `fragments` 테이블의 유형별, 계층별 카운트 및 유용성 점수 평균 |
-| `memory://topics` | 주제 목록 | `fragments` 테이블의 모든 고유한 `topic` 레이블 목록 |
+| `memory://stats` | 범위 내 통계 | 리소스의 key/workspace 범위에서 현재 유효한 default agent 파편의 유형별·계층별 카운트 및 유용성 평균 |
+| `memory://topics` | 범위 내 주제 목록 | 같은 범위의 현재 유효한 default agent 파편에서 고유 topic 목록 |
 | `memory://config` | 시스템 설정 | `MEMORY_CONFIG`에 정의된 가중치 및 TTL 임계값 |
 | `memory://active-session` | 세션 활동 로그 | `SessionActivityTracker`(Redis)에 기록된 현재 세션의 도구 사용 이력 |
+
+두 리소스에는 `includePeerAgents` 입력 경로가 없으므로 master도 전체 agent 집계를 요청할 수 없다. superseded 파편(`valid_to IS NOT NULL`)은 제외한다.
+
+Agent 조회는 생략 시 `default`, 지정 시 해당 agent와 `default`를 포함한다. 전환 릴리즈는 `MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE=true`가 기본이며 일반 API key의 기존 specific-agent 주장을 경고·계수와 함께 허용한다. false로 설정한 strict 모드에서는 master만 specific agent를 지정할 수 있고, `includePeerAgents`는 설정과 무관하게 항상 master 전용이다. `search_traces`와 `reconstruct_history`도 이 기본 agent 필터 때문에 종전 관리 호출보다 결과가 줄어들 수 있다.
+
+`fragment_history`와 `graph_explore`의 ID 조회에도 workspace 필터가 적용된다. 예를 들어 default_workspace 없는 일반 키로 proj에 저장한 파편의 이력은 `{ "id": "fragment-id", "workspace": "proj" }`로 조회한다. master는 `{ "id": "fragment-id", "allWorkspaces": true }`로 workspace 필터를 제거한다. `graph_explore`는 두 예시의 `id`를 `startId`로 바꿔 호출한다. workspace 생략 시 global-only가 되어 종전 ID-only 조회가 not found로 바뀔 수 있다.
 
 ---
 
@@ -331,7 +337,7 @@ API 키의 일일 호출 제한을 변경한다. 마스터 키 인증 필요.
 | linkRelationType | string | - | 연결 파편 관계 유형 필터 (related, caused_by, resolved_by, part_of, contradicts) |
 | threshold | number | - | similarity 임계값 (0~1) |
 | includeSuperseded | boolean | - | 만료(superseded) 파편 포함. 기본 false. |
-| includePeerAgents | boolean | - | true 시 같은 키/workspace 스코프 내 다른 agentId 파편 포함(멀티에이전트 협업용). 키·workspace 경계는 유지. 기본 false. |
+| includePeerAgents | boolean | - | master 전용. true 시 같은 키/workspace 스코프 내 다른 agentId 파편 포함. 일반 API 키는 권한 오류. 기본 false. |
 | includeKeyName | boolean | - | true 시 각 파편에 key_id와 key_name(액세스 키 라벨)을 포함한다. 같은 키 그룹 스코프의 정보만 노출된다. 기본 false. |
 | asOf | string | - | ISO 8601. 특정 시점 기준 유효 파편만. |
 | excludeSeen | boolean | - | context()에서 이미 주입된 파편 제외. 기본 true. |
@@ -917,7 +923,7 @@ Anchor + Core + Learning + Working Memory와 session_reflect를 분리 로드한
 
 ## MCP 도구 — memory_stats
 
-파편 기억 시스템 통계 조회. 전체 파편 수, TTL 분포, 유형별 통계를 반환한다.
+master key 전용 파편 기억 시스템 통계 조회. 전체 파편 수, TTL 분포, 유형별 통계를 반환한다. 테넌트별 scope가 없는 전역 집계이므로 일반 API key에는 노출하지 않는다.
 
 ### 파라미터
 
@@ -977,7 +983,7 @@ workspace 기입 현황과 세션당 파편 분포를 반환한다.
 
 ## MCP 도구 — session_rotate
 
-현재 세션을 종료하고 새 `sessionId`를 발급한다. 토큰 탈취 의심 시 또는 주기적 로테이션에 사용한다. 동일 `bound_key_id` / `workspace` / `permissions`가 새 세션으로 이관된다.
+현재 세션을 종료하고 새 `sessionId`를 발급한다. 토큰 탈취 의심 시 또는 주기적 로테이션에 사용한다. 회전 시 현재 credential을 다시 검증하여 `bound_key_id` / key group / `permissions`를 최신 값으로 갱신하고, 기존 세션에서 선택된 `defaultWorkspace`와 `mode`는 그대로 유지한다.
 
 ### 파라미터
 
@@ -997,6 +1003,9 @@ workspace 기입 현황과 세션당 파편 분포를 반환한다.
 |------|------|------|------|
 | startId | string | O | 시작 파편 ID (error 파편 권장) |
 | agentId | string | - | 에이전트 ID |
+| includePeerAgents | boolean | - | master 전용. 같은 key/workspace 범위의 다른 agent 노드 포함. 기본 false. |
+| workspace | string | - | 시작·이웃 파편의 범위. 생략 시 key 기본 workspace를 사용하며 둘 다 없으면 전역(NULL)만 조회. |
+| allWorkspaces | boolean | - | master 전용. true이면 시작·이웃 파편의 workspace 필터를 제거한다. agent/key 경계는 유지. 기본 false. |
 
 ---
 
@@ -1010,7 +1019,9 @@ workspace 기입 현황과 세션당 파편 분포를 반환한다.
 |------|------|------|------|
 | id | string | O | 조회할 파편 ID |
 | agentId | string | - | 에이전트 ID |
-| includePeerAgents | boolean | - | true 시 같은 API 키 스코프 내 다른 agentId의 파편 이력도 조회한다. 테넌트(키) 경계는 완화되지 않는다. 기본 false. |
+| includePeerAgents | boolean | - | master 전용. 같은 key/workspace 범위의 다른 agent 이력 포함. 일반 API 키는 권한 오류. 기본 false. |
+| workspace | string | - | 현재 파편·버전·superseded chain의 범위. 생략 시 key 기본 workspace를 사용하며 둘 다 없으면 전역(NULL)만 조회. |
+| allWorkspaces | boolean | - | master 전용. true이면 현재 파편·버전·superseded chain의 workspace 필터를 제거한다. agent/key 경계는 유지. 기본 false. |
 
 ---
 
@@ -1040,6 +1051,9 @@ case_id 또는 entity 기반으로 작업 히스토리를 시간순으로 재구
 | query | string | - | 추가 키워드 필터 |
 | limit | number | - | 기본 100, 최대 500 |
 | workspace | string | - | 워크스페이스 필터. 지정 시 해당 workspace + 전역(NULL) 파편만 대상. |
+| allWorkspaces | boolean | - | master 전용. true이면 timeline·event·evidence·인과 링크의 workspace 필터를 제거한다. |
+| agentId | string | - | 생략 시 default 공유 범위. strict 모드에서 특정 agent 지정은 master 전용이며, 전환 릴리즈의 legacy 호환 기본 true는 일반 키의 기존 주장을 임시 허용. |
+| includePeerAgents | boolean | - | master 전용. 같은 key/workspace 범위의 모든 agent 포함. 기본 false. |
 
 ### 반환값
 
@@ -1068,6 +1082,9 @@ fragments를 정확 매칭으로 탐색한다 (recall의 시맨틱 검색과 달
 | time_range | object | - | 시간 범위 필터. from(시작 시각, ISO 8601), to(종료 시각, ISO 8601) 포함. |
 | limit | number | - | 기본 20, 최대 100 |
 | workspace | string | - | 워크스페이스 필터. 지정 시 해당 workspace + 전역(NULL) 파편만 대상. |
+| allWorkspaces | boolean | - | master 전용. true이면 trace의 workspace 필터를 제거한다. |
+| agentId | string | - | 생략 시 default 공유 범위. strict 모드에서 특정 agent 지정은 master 전용이며, 전환 릴리즈의 legacy 호환 기본 true는 일반 키의 기존 주장을 임시 허용. |
+| includePeerAgents | boolean | - | master 전용. 같은 key/workspace 범위의 모든 agent 포함. 기본 false. |
 
 ---
 

--- a/docs/configuration.en.md
+++ b/docs/configuration.en.md
@@ -25,7 +25,7 @@
 | EVALUATOR_MAX_QUEUE | 100 | MemoryEvaluator queue size cap (older jobs dropped on overflow) |
 | OAUTH_TRUSTED_ORIGINS | (none) | Additional OAuth redirect_uri trusted domains (comma-separated, origin level). Added on top of default trusted domains (claude.ai, chatgpt.com, platform.openai.com, copilot.microsoft.com, gemini.google.com). Only specify additional origins to allow |
 | MCP_STRICT_ORIGIN | false | When `true`, enables strict Origin header validation (DNS rebinding defense). Requests from Origins not in the allowlist (`OAUTH_TRUSTED_ORIGINS` + `ALLOWED_ORIGINS` + default trusted domains) are rejected with 403. Requests without an Origin header (CLI/curl) are always allowed. **opt-in** — defaults to `false` to preserve existing behavior |
-| MCP_REJECT_NONAPIKEY_OAUTH | true | Set to `false` to allow `is_api_key=false` OAuth tokens (backward compatibility). Default `true` — non-API-key OAuth tokens create a `keyId=null` session with master-level access to all fragments. API-key-based OAuth tokens (`is_api_key=true`) and Bearer ACCESS_KEY direct use are unaffected |
+| MCP_REJECT_NONAPIKEY_OAUTH | true | The default `true` rejects authentication with `is_api_key=false` OAuth tokens. `false` permits that authentication only and never grants master privileges. OAuth sessions without an API-key binding receive `-32001` on tool calls. API-key-based OAuth tokens (`is_api_key=true`) and direct Bearer ACCESS_KEY use are unaffected |
 | MCP_ALLOW_AUTO_DCR_REGISTER | false | Set to `true` to allow auto-registration of unregistered `client_id` in `/authorize` (legacy behavior). Default `false` — enforces RFC 7591 `POST /register` endpoint for client registration |
 | OAUTH_ALLOWED_REDIRECT_URIS | (none) | OAuth redirect_uri exact-match allowed list (comma-separated). Operates independently of OAUTH_TRUSTED_ORIGINS |
 | DEFAULT_DAILY_LIMIT | 10000 | Default daily call limit when creating API keys |
@@ -267,6 +267,8 @@ This feature operates asynchronously only when `REDIS_ENABLED=true`. When `REDIS
 | REDIS_PORT | 6379 | Redis server port |
 | REDIS_PASSWORD | (none) | Redis authentication password |
 | REDIS_DB | 0 | Redis database number |
+| MEMENTO_REDIS_SESSION_FAIL_CLOSED | false | Fail the request when Redis session persistence fails. When false, warn and continue with the in-memory session |
+| MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE | true | Transition compatibility for API-key non-default agentId claims. Each use emits a warning and increments `mcp_legacy_unbound_agent_scope_total`. It does not authenticate agents sharing a key; migrate clients, confirm no further increments, then set false for strict mode. includePeerAgents always requires master authentication |
 | REDIS_MASTER_NAME | mymaster | Sentinel master name |
 | REDIS_SENTINELS | localhost:26379, localhost:26380, localhost:26381 | Sentinel node list. Comma-separated host:port format |
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@
 | EVALUATOR_MAX_QUEUE | 100 | MemoryEvaluator 큐 크기 상한 (초과 시 오래된 작업 드롭) |
 | OAUTH_TRUSTED_ORIGINS | (없음) | OAuth redirect_uri 신뢰 도메인 추가 목록 (쉼표 구분, origin 단위). 기본 신뢰 도메인(claude.ai, chatgpt.com, platform.openai.com, copilot.microsoft.com, gemini.google.com)에 추가로 허용할 origin만 지정 |
 | MCP_STRICT_ORIGIN | false | `true`로 설정 시 Origin 헤더 엄격 검증 활성화 (DNS rebinding 방어). 허용 목록(`OAUTH_TRUSTED_ORIGINS` + `ALLOWED_ORIGINS` + 기본 신뢰 도메인)에 없는 Origin에서 온 요청을 403으로 거부. Origin 헤더 없는 요청(CLI/curl)은 항상 허용. **opt-in** — 기본 `false`로 기존 동작 유지 |
-| MCP_REJECT_NONAPIKEY_OAUTH | true | `false`로 설정 시 `is_api_key=false` OAuth 토큰 허용 (하위 호환). 기본 `true` — non-API-key OAuth 토큰은 `keyId=null` 세션을 생성하여 모든 파편에 master 권한으로 접근할 수 있으므로 차단. API 키 기반 OAuth 토큰(`is_api_key=true`)과 Bearer ACCESS_KEY 직접 사용은 영향 없음 |
+| MCP_REJECT_NONAPIKEY_OAUTH | true | 기본 `true`는 `is_api_key=false` OAuth 토큰 인증을 거부한다. `false`는 해당 인증만 허용하며 master 권한을 부여하지 않는다. API 키 바인딩이 없는 OAuth 세션의 도구 호출은 `-32001`로 거부된다. API 키 기반 OAuth 토큰(`is_api_key=true`)과 Bearer ACCESS_KEY 직접 사용은 영향 없음 |
 | MCP_ALLOW_AUTO_DCR_REGISTER | false | `true`로 설정 시 `/authorize`에서 미등록 `client_id`의 자동 등록 허용 (기존 동작). 기본 `false` — RFC 7591 `POST /register` 엔드포인트 경유 강제 |
 | OAUTH_ALLOWED_REDIRECT_URIS | (없음) | OAuth redirect_uri 정확 일치 허용 목록 (쉼표 구분). OAUTH_TRUSTED_ORIGINS와 별도로 동작 |
 | DEFAULT_DAILY_LIMIT | 10000 | API 키 생성 시 기본 일일 호출 한도 |
@@ -267,6 +267,8 @@ POSTGRES_* 접두어가 DB_* 접두어보다 우선한다. 두 형식을 혼용�
 | REDIS_PORT | 6379 | Redis 서버 포트 |
 | REDIS_PASSWORD | (없음) | Redis 인증 비밀번호 |
 | REDIS_DB | 0 | Redis 데이터베이스 번호 |
+| MEMENTO_REDIS_SESSION_FAIL_CLOSED | false | true이면 Redis 세션 저장 실패 시 요청을 실패 처리. false이면 경고 후 in-memory 세션으로 계속 동작 |
+| MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE | true | 전환 기간 동안 일반 API key의 non-default agentId 주장을 허용. 실제 사용 시 경고와 `mcp_legacy_unbound_agent_scope_total` 기록. 같은 key 내부 agent 인증은 보장하지 않으며, 이관 후 계수 증가가 없는지 확인하고 false로 strict 모드 적용. includePeerAgents는 항상 master 전용 |
 | REDIS_MASTER_NAME | mymaster | Sentinel 마스터 이름 |
 | REDIS_SENTINELS | localhost:26379, localhost:26380, localhost:26381 | Sentinel 노드 목록. 쉼표로 구분된 host:port 형식 |
 

--- a/docs/internals.en.md
+++ b/docs/internals.en.md
@@ -234,6 +234,12 @@ Trigger condition: `(now - session.lastAccessedAt) > idleThresholdMs` AND (`sess
 
 When an SSE stream closes (`res.on('close')`), the server removes only the SSE response object; the session itself is kept alive. The session persists until its Redis TTL expires, allowing a reconnecting client to resume the same session.
 
+### OAuth security model — identities without a keyId are not master
+
+Authentication preserves an explicit `isMaster` decision instead of inferring master access from `keyId=null`. Direct access-key and explicit auth-disabled sessions are master; API-key-bound OAuth sessions carry their key, group, workspace, and permissions. A generic non-API-key OAuth session remains `isMaster=false`. Even when compatibility mode permits that authentication, the missing key/permission identity causes memory tools and resource reads to fail closed. The current API-key/OAuth schema does not support binding a non-default agent identity.
+
+OAuth authentication first tries `bound_key_id` via `validateApiKeyById`, then `is_api_key=true` via `validateApiKeyFromDB(client_id)`. Generic non-API-key OAuth is rejected by default with `MCP_REJECT_NONAPIKEY_OAUTH=true`; setting false permits authentication only, not memory tool/resource access without a bound key/permission identity.
+
 ### OAuth refresh_token is_api_key Propagation
 
 When refreshing a token via `POST /token` with `grant_type=refresh_token`, the `is_api_key` flag from the original token is propagated to the newly issued access_token and refresh_token. API key-based clients retain the same isolation context after a refresh.
@@ -619,7 +625,7 @@ The resolved mode is stored in the session object and reused for all subsequent 
 
 ### tools/list Filtering
 
-`filterTools(tools, presetName, isMaster)` removes tools in the `excluded_tools` set and returns the filtered list. Presets with `requiresMaster=true` are only applied to master-key sessions (`keyId === null`); regular API key sessions ignore such presets and receive the full tool list.
+`filterTools(tools, presetName, isMaster)` removes tools in the `excluded_tools` set and returns the filtered list. Presets with `requiresMaster=true` apply only to explicitly authenticated master sessions (`isMaster === true`). API-key sessions ignore master-only presets but still apply permission and master-only tool filtering.
 
 When assembling the `get_skill_guide` response, `getSkillGuideOverride(presetName, isMaster)` returns the `skill_guide_override` string from the preset. If present, this overrides the default skill guide text.
 
@@ -770,3 +776,11 @@ export async function dispatchChain(chain, prompt, options = {}, deps = {})
 The chain is an array of provider configurations. Providers are tried in order; on success the result is returned immediately. On failure (429, semaphore timeout, error), execution moves to the next fallback provider.
 
 **Concurrency control:** `getSemaphore(chainKey, limit, waitMs)` acquires a per-provider independent semaphore. The chainKey is composed of `provider|baseUrl|model|apiKeyHash`. Exceeding `LLM_CONCURRENCY_WAIT_MS` (default 30000ms) records the current provider as failed and tries the next. Chain deadline is calculated from `deps.startedAt` and `LLM_CHAIN_TIMEOUT_MS`; when remaining time reaches 0 the chain terminates immediately.
+
+## Agent scope and snapshot migration
+
+`resolveAgentScope` validates explicit `_isMaster=true` for peer requests at scope resolution, enforcing the same master contract for CLI/embedded callers. Omitting agentId selects default; specifying one selects that agent plus default. Legacy unbound compatibility defaults to true for this transition release; each relaxed request emits a warning and increments `mcp_legacy_unbound_agent_scope_total`. After migration, setting false rejects non-default agent requests from ordinary API keys.
+
+Migration-047 only adds snapshot columns to `fragment_versions`/`case_events`. Inspect pending warnings from `migrate`, stop old writers, then run the CLI backfill. NULL snapshots are quarantined from reads, including peer reads. Backfill recounts after a zero-update batch; remaining backfillable or sourceMissing/sourceDeleted rows produce `SNAPSHOT_BACKFILL_INCOMPLETE`. Shared normalization moves the fragment and version agent snapshots in one transaction. Rollback drops snapshot columns but does not undo normalization.
+
+Old sessions require reconnection and initialize. Old sessions reused without bearer credentials and without isMaster are denied tool access. `memory://stats`/`memory://topics` aggregate only current default-agent fragments and expose no master peer input. `search_traces`/`reconstruct_history` also default to the default-agent scope.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -241,11 +241,13 @@ SSE 스트림이 닫히면(`res.on('close')`) 서버는 SSE 응답 객체만 제
 
 ### OAuth 보안 모델 — keyId가 없는 OAuth는 master 권한이 아님
 
+인증은 `keyId=null`에서 권한을 추론하지 않고 명시적 `isMaster`를 보존한다. 직접 access-key와 명시적 auth-disabled 세션은 master이고, API-key-bound OAuth는 해당 key/group/workspace/permissions를 유지한다. generic non-API-key OAuth는 `isMaster=false`로 남는다.
+
 `validateAuthentication`의 OAuth 분기는 세 가지 우선순위 경로로 처리된다.
 
 1. **bound_key_id 경로 (1순위)**: 토큰의 `bound_key_id` 필드가 있으면 `validateApiKeyById(bound_key_id)`로 UUID 직접 조회. name-based client_id 바인딩 방식이 이 경로를 사용한다. 성공 시 `keyId`/`groupKeyIds`/`permissions` 반환. `mcp_oauth_bound_client_authenticated_total` 카운터 증가.
 2. **is_api_key=true 경로 (2순위)**: `client_id`가 원본 API 키 문자열인 경우 `validateApiKeyFromDB(client_id)`로 조회. bound_key_id 조회 실패 시에도 이 경로로 낙하.
-3. **non-API-key OAuth (3순위)**: `MCP_REJECT_NONAPIKEY_OAUTH=true`(기본)이면 `{ valid: false, error: "non-API-key OAuth denied" }` 반환. `mcp_oauth_nonapikey_rejected_total` + `memento_tenant_isolation_blocked_total{component="oauth_nonapikey_denied"}` 카운터 증가. `false`이면 하위 호환 동작 (`keyId=null` 세션 — 운영 환경에서 절대 사용하지 말 것).
+3. **non-API-key OAuth (3순위)**: `MCP_REJECT_NONAPIKEY_OAUTH=true`(기본)이면 `{ valid: false, error: "non-API-key OAuth denied" }` 반환. `mcp_oauth_nonapikey_rejected_total` + `memento_tenant_isolation_blocked_total{component="oauth_nonapikey_denied"}` 카운터 증가. `false`여도 세션은 `isMaster=false`이며, key/permission identity가 없으므로 memory tool과 resource read는 fail-closed로 거부된다. 현재 API key/OAuth 스키마는 non-default agent identity 바인딩을 지원하지 않는다.
 
 ### OAuth name-based client_id 바인딩
 
@@ -709,7 +711,7 @@ initialize 이후 모든 요청에서 `MCP-Protocol-Version` 헤더를 검사한
 
 ### tools/list 필터링
 
-`filterTools(tools, presetName, isMaster)` 함수가 `excluded_tools` Set에 포함된 도구를 제거한 목록을 반환한다. `requiresMaster=true` 프리셋은 마스터 키 세션(`keyId === null`)에만 적용되며, 일반 API 키 세션에서는 프리셋을 무시하고 전체 도구를 노출한다.
+`filterTools(tools, presetName, isMaster)` 함수가 `excluded_tools` Set에 포함된 도구를 제거한 목록을 반환한다. `requiresMaster=true` 프리셋은 명시적으로 인증된 마스터 세션(`isMaster === true`)에만 적용된다. 일반 API 키는 master 전용 프리셋을 무시하되 permission/master 전용 도구 필터는 계속 적용한다.
 
 `get_skill_guide` 도구 응답 조립 시 `getSkillGuideOverride(presetName, isMaster)`가 `skill_guide_override` 문자열을 반환하면 기본 가이드 대신 해당 문자열이 사용된다.
 
@@ -861,6 +863,14 @@ export async function dispatchChain(chain, prompt, options = {}, deps = {})
 체인은 provider 설정 배열이며, 첫 번째 provider부터 순서대로 시도하여 성공 시 결과를 반환한다. 실패(429, semaphore timeout, 오류) 시 다음 fallback provider로 이동한다.
 
 **동시성 제어:** `getSemaphore(chainKey, limit, waitMs)`로 provider별 독립 semaphore를 획득한다. chainKey는 `provider|baseUrl|model|apiKeyHash` 조합. `LLM_CONCURRENCY_WAIT_MS`(기본 30000ms) 초과 시 해당 provider 실패 처리. chain deadline은 `deps.startedAt`과 `LLM_CHAIN_TIMEOUT_MS`로 계산하며, 잔여 시간이 0 이하이면 즉시 chain 종료.
+
+## Agent scope와 snapshot 이관
+
+`resolveAgentScope`는 범위 해석 자체에서 peer 요청의 명시적 `_isMaster=true`를 검사하므로 CLI/임베디드 호출에도 master 계약을 적용한다. `agentId` 생략은 `default`이고, 특정 agent 요청은 해당 agent와 `default`를 선택한다. 전환 릴리즈의 legacy unbound 호환은 기본 true이며, 완화 경로 사용마다 경고와 `mcp_legacy_unbound_agent_scope_total`을 기록한다. 이관 후 false로 전환하면 일반 API key의 non-default agent 요청을 거부한다.
+
+migration-047은 `fragment_versions`/`case_events` snapshot 컬럼만 추가한다. `migrate`의 잔량 경고를 확인하고 구 writer 종료 후 CLI backfill을 실행한다. NULL은 peer를 포함한 읽기에서 격리된다. backfill은 갱신 0건 이후 재집계하며, backfillable 또는 sourceMissing/sourceDeleted 잔량은 `SNAPSHOT_BACKFILL_INCOMPLETE`로 보고한다. 공유 정규화는 파편과 version agent snapshot을 같은 트랜잭션에서 이동한다. 롤백은 snapshot 컬럼을 삭제할 뿐 정규화를 복원하지 않는다.
+
+구 세션은 재연결·initialize가 필요하다. bearer 없이 재사용한 구 세션에 isMaster가 없으면 도구 호출을 거부한다. `memory://stats`/`memory://topics`는 현재 default-agent 파편만 집계하며 master peer 입력 통로가 없다. `search_traces`/`reconstruct_history`도 기본 default-agent 범위를 적용한다.
 
 ## 프로세스 에러 가드
 

--- a/lib/admin/admin-memory.js
+++ b/lib/admin/admin-memory.js
@@ -738,6 +738,7 @@ export async function handleSearch(req, res, url) {
       pageSize    : body?.pageSize,
       allWorkspaces: true,
       _isMaster   : true,
+      includePeerAgents: body?.include_peer_agents === true,
       _keyId      : scope.keyId,
       _groupKeyIds: scope.groupKeyIds ?? undefined
     });

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -176,7 +176,7 @@ export async function validateAuthentication(req, msg) {
           recordAuthDenied("oauth_nonapikey_denied");
           return { valid: false, error: "non-API-key OAuth denied" };
         }
-        return { valid: true, oauth: true, client_id: oauthResult.client_id };
+        return { valid: true, oauth: true, isMaster: false, client_id: oauthResult.client_id, permissions: null };
       }
 
       /** DB API 키 검증 (fallback — 마스터 키/OAuth 모두 실패 시) */

--- a/lib/cli/anchor-scope.js
+++ b/lib/cli/anchor-scope.js
@@ -1,0 +1,203 @@
+/**
+ * non-default anchor 범위 inventory 및 승인된 공유 anchor 정규화.
+ * 기본은 dry-run이며 content를 출력하지 않는다.
+ */
+import fs from "node:fs";
+import { shutdownPool } from "../tools/db.js";
+import { MemoryManager } from "../memory/MemoryManager.js";
+import { FragmentStore } from "../memory/write/FragmentStore.js";
+import { classifyAnchors } from "../memory/admin/AnchorScopeInventory.js";
+import {
+  backfillAgentScopeSnapshots,
+  assertBackfillComplete,
+  getAgentScopeBackfillStatus,
+  getPendingScopeSnapshotCounts,
+  hasAgentScopeSnapshotSchema
+} from "../memory/admin/AgentScopeBackfill.js";
+
+export const usage = [
+  "Usage: memento-mcp anchor-scope [options]",
+  "",
+  "Inventory non-default anchors. Default: dry-run.",
+  "",
+  "Options:",
+  "  --classifications <file>   JSON: { shared: [ids], private: [ids] }",
+  "  --workspace <name>         Restrict inventory to one workspace",
+  "  --agent <id>               Restrict inventory to one current agent",
+  "  --include-non-anchors      Include every legacy non-default fragment",
+  "  --backfill-snapshots       Inspect/backfill version and case-event snapshots",
+  "  --batch-size <n>           Snapshot backfill batch size (default: 500)",
+  "  --execute                  Normalize approved shared anchors to default",
+  "  --approve-shared           Required together with --execute",
+  "  --approve-backfill         Required for snapshot backfill execution",
+  "  --json                     Accepted for compatibility; output is always JSON",
+].join("\n");
+
+function loadClassifications(file) {
+  if (!file) return { shared: new Set(), private: new Set() };
+  const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+  return {
+    shared : new Set(Array.isArray(raw.shared) ? raw.shared.map(String) : []),
+    private: new Set(Array.isArray(raw.private) ? raw.private.map(String) : [])
+  };
+}
+
+export function parseStrictBooleanFlag(args, name) {
+  const value = args[name];
+  if (value === undefined || value === false) return false;
+  if (value === true) return true;
+  throw new Error(`--${name} must be supplied once as a boolean flag`);
+}
+
+export function parseSnapshotBatchSize(args) {
+  const value = args["batch-size"];
+  if (value === undefined) return 500;
+  const batchSize = Number(value);
+  if (!["string", "number"].includes(typeof value)
+      || !Number.isInteger(batchSize) || batchSize < 1 || batchSize > 10_000) {
+    throw new Error("--batch-size must be an integer between 1 and 10000");
+  }
+  return batchSize;
+}
+
+export function assertNoNormalizationFailures(results) {
+  const failures = results.filter(result => !result.updated || result.cacheConsistent === false);
+  if (failures.length > 0) {
+    throw new Error(`agent scope normalization failed for ${failures.length} item(s)`);
+  }
+}
+
+/**
+ * 승인 목록 전체의 id/agent/workspace를 먼저 확인한 뒤에만 실제 정규화를 시작한다.
+ * 따라서 global과 named workspace 항목이 섞여 있어도 잘못된 후행 항목 때문에
+ * 선행 항목만 바뀌는 예측 가능한 부분 적용을 피한다.
+ */
+export async function normalizeApprovedFragments(manager, approved, { anchorsOnly = true } = {}) {
+  const prepared = approved.map(item => ({
+    item,
+    options: { anchorsOnly, workspace: item.workspace ?? null, allWorkspaces: false }
+  }));
+
+  for (const { item, options } of prepared) {
+    const validation = await manager.validateFragmentAgentNormalization(
+      item.id, item.agentId, options
+    );
+    if (!validation.valid) {
+      throw new Error(`agent scope normalization preflight failed for ${item.id}: ${validation.error}`);
+    }
+  }
+
+  const results = [];
+  for (const { item, options } of prepared) {
+    const result = await manager.normalizeFragmentAgentToDefault(
+      item.id, item.agentId, options
+    );
+    results.push({
+      id: item.id,
+      updated: result.updated === true,
+      error: result.error,
+      ...(result.cacheWarning ? { cacheWarning: result.cacheWarning } : {}),
+      ...(result.databaseUpdated === true ? { databaseUpdated: true } : {}),
+      ...(result.cacheConsistent === false ? { cacheConsistent: false } : {})
+    });
+  }
+  return results;
+}
+
+export default async function anchorScope(args) {
+  // Validate even dry-runs before any database, file, or normalization operation.
+  const batchSize = parseSnapshotBatchSize(args);
+  const execute = parseStrictBooleanFlag(args, "execute");
+  const approveShared = parseStrictBooleanFlag(args, "approve-shared");
+  const approveBackfill = parseStrictBooleanFlag(args, "approve-backfill");
+  const includeNonAnchors = parseStrictBooleanFlag(args, "include-non-anchors");
+  const snapshotMode = parseStrictBooleanFlag(args, "backfill-snapshots");
+  if (snapshotMode) {
+    if (execute && !approveBackfill) {
+      throw new Error("--backfill-snapshots --execute requires explicit --approve-backfill");
+    }
+    if (!execute && approveBackfill) {
+      throw new Error("--approve-backfill requires --execute");
+    }
+    try {
+      const before = await getAgentScopeBackfillStatus();
+      if (!before.migrationReady) {
+        throw new Error("migration-047 must be applied before snapshot backfill");
+      }
+      const updated = execute
+        ? await backfillAgentScopeSnapshots({ batchSize })
+        : null;
+      const after = execute ? await getAgentScopeBackfillStatus() : null;
+      console.log(JSON.stringify({ dryRun: !execute, before, ...(updated ? { updated, after } : {}) }, null, 2));
+      if (execute) assertBackfillComplete(after);
+      return;
+    } catch (error) {
+      if (error.code === "SNAPSHOT_BACKFILL_INCOMPLETE") {
+        console.error(JSON.stringify({
+          error: error.code, progress: error.progress, after: error.status
+        }, null, 2));
+      }
+      throw error;
+    } finally {
+      await shutdownPool();
+    }
+  }
+
+  if (execute && !approveShared) {
+    throw new Error("--execute requires explicit --approve-shared");
+  }
+  if (execute && !args.classifications) {
+    throw new Error("--execute requires --classifications <file>");
+  }
+
+  try {
+    if (execute && !await hasAgentScopeSnapshotSchema()) {
+      throw new Error("migration-047 must be applied before agent scope normalization");
+    }
+    const classifications = loadClassifications(args.classifications);
+    const store = new FragmentStore();
+    const rows = await store.inventoryNonDefaultFragments({
+      workspace: args.workspace || null,
+      agentId  : args.agent || null,
+      anchorsOnly: !includeNonAnchors
+    });
+    const inventory = classifyAnchors(rows, classifications);
+    const approved = inventory.filter(item => item.category === "shared");
+    const results = [];
+
+    if (execute) {
+      const pendingSnapshots = await getPendingScopeSnapshotCounts(
+        approved.map(item => item.id)
+      );
+      if (pendingSnapshots.total > 0) {
+        throw new Error(
+          `approved fragments have ${pendingSnapshots.total} pending scope snapshot(s) ` +
+          `(versions=${pendingSnapshots.fragmentVersions}, events=${pendingSnapshots.caseEvents}); ` +
+          "run --backfill-snapshots first"
+        );
+      }
+      const manager = MemoryManager.create();
+      results.push(...await normalizeApprovedFragments(manager, approved, {
+        anchorsOnly: !includeNonAnchors
+      }));
+    }
+
+    const summary = {
+      dryRun: !execute,
+      counts: {
+        total      : inventory.length,
+        shared     : approved.length,
+        private    : inventory.filter(item => item.category === "private").length,
+        unconfirmed: inventory.filter(item => item.category === "unconfirmed").length
+      },
+      scope: includeNonAnchors ? "all-fragments" : "anchors-only",
+      inventory,
+      ...(execute ? { results } : { wouldNormalize: approved.map(item => item.id) })
+    };
+
+    console.log(JSON.stringify(summary, null, 2));
+    assertNoNormalizationFailures(results);
+  } finally {
+    await shutdownPool();
+  }
+}

--- a/lib/cli/completion.js
+++ b/lib/cli/completion.js
@@ -42,6 +42,7 @@ const COMMANDS = [
   "completion",
   "session",
   "benchmark",
+  "anchor-scope",
 ];
 
 /** 공통 플래그 목록 */

--- a/lib/cli/recall.js
+++ b/lib/cli/recall.js
@@ -23,6 +23,7 @@ export const usage = [
   "  --time-range <from,to>    ISO date range, e.g. 2026-01-01,2026-04-20",
   "  --workspace <name>        Search this workspace plus global fragments",
   "  --all-workspaces          Master-only explicit cross-workspace search",
+  "  --include-peer-agents     Master-only: include all agents within key/workspace scope",
   "  --format table|json|csv   Output format (default: table if TTY, json otherwise)",
   "  --json                    Shorthand for --format json",
   "  --remote <URL>            MCP 원격 서버 URL (env: MEMENTO_CLI_REMOTE)",
@@ -100,6 +101,7 @@ export default async function recall(args) {
     pageSize    : limit,
     workspace   : args.workspace || undefined,
     allWorkspaces: args["all-workspaces"] === true,
+    includePeerAgents: args["include-peer-agents"] === true,
   };
 
   if (args["time-range"]) {

--- a/lib/cli/session.js
+++ b/lib/cli/session.js
@@ -340,7 +340,7 @@ async function cmdRotate(args, remoteUrl, remoteKey, timeoutMs) {
     result = await remoteRotate(remoteUrl, remoteKey, sessionId, reason, timeoutMs);
   } else {
     const { rotateSession } = await import("../sessions.js");
-    const raw = await rotateSession(sessionId, { reason });
+    const raw = await rotateSession(sessionId, { reason, trustedLocal: true });
     result = {
       oldSessionId: raw.oldSessionId,
       newSessionId: raw.newSessionId,

--- a/lib/config.js
+++ b/lib/config.js
@@ -73,6 +73,8 @@ export const REDIS_HOST         = process.env.REDIS_HOST || "localhost";
 export const REDIS_PORT         = Number(process.env.REDIS_PORT || 6379);
 export const REDIS_PASSWORD     = process.env.REDIS_PASSWORD || undefined;
 export const REDIS_DB           = Number(process.env.REDIS_DB || 0);
+/** Redis session write failure 시 in-memory fallback을 막는 명시적 보안 opt-in. */
+export const REDIS_SESSION_FAIL_CLOSED = process.env.MEMENTO_REDIS_SESSION_FAIL_CLOSED === "true";
 
 /** Redis Sentinel 설정 */
 export const REDIS_MASTER_NAME  = process.env.REDIS_MASTER_NAME || "mymaster";

--- a/lib/config.js
+++ b/lib/config.js
@@ -55,6 +55,8 @@ export const ACCESS_KEY         = process.env.MEMENTO_ACCESS_KEY || "";
  * 활성화 시 서버는 모든 요청을 master 권한으로 처리한다 (개발/테스트 전용).
  */
 export const AUTH_DISABLED      = process.env.MEMENTO_AUTH_DISABLED === "true";
+/** agent identity binding 도입 전 legacy API key의 기존 agentId 주장을 임시 허용. */
+export const ALLOW_LEGACY_UNBOUND_AGENT_SCOPE = process.env.MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE !== "false";
 export const SESSION_TTL_MS            = Number(process.env.SESSION_TTL_MINUTES || 43200) * 60 * 1000;
 export const OAUTH_TOKEN_TTL_SECONDS   = Number(process.env.SESSION_TTL_MINUTES || 43200) * 60;
 export const OAUTH_REFRESH_TTL_SECONDS = OAUTH_TOKEN_TTL_SECONDS * 2;

--- a/lib/handlers/mcp-handler.js
+++ b/lib/handlers/mcp-handler.js
@@ -33,8 +33,8 @@ import { getPreset } from "../memory/ModeRegistry.js";
 /**
  * 인증된 요청에서 토큰-세션 재사용용 캐시 키를 파생한다.
  * 우선순위: Authorization Bearer → memento-access-key → initialize.params.accessKey.
- * 토큰 원문은 저장하지 않고 sha256 단축 해시만 키로 사용한다. master 세션은 keyId가 null이므로
- * 같은 마스터 키라도 정상적으로 하나의 세션을 공유한다.
+ * 토큰 원문은 저장하지 않고 sha256 단축 해시만 키로 사용한다. master 여부는
+ * keyId=null로 추론하지 않고 인증 결과의 명시적 isMaster를 사용한다.
  *
  * @returns {string|null} `token:<hash16>` 또는 null (토큰을 식별할 수 없는 경우)
  */
@@ -54,8 +54,33 @@ export function deriveTokenKey(req, msg, authCheck) {
 
   const hash = crypto.createHash("sha256").update(String(raw)).digest("hex").slice(0, 16);
   /** keyId 네임스페이스까지 포함해 cross-tenant 오인식을 차단 */
-  const ns = authCheck?.keyId || "master";
+  const ns = authCheck?.isMaster === true
+    ? "master"
+    : (authCheck?.keyId ?? "oauth");
   return `${ns}:${hash}`;
+}
+
+export function hasSessionIdentityMismatch(existingSession, authResult) {
+  if (!existingSession) return false;
+  return (existingSession.keyId ?? null) !== (authResult?.keyId ?? null)
+    || (existingSession.isMaster === true) !== (authResult?.isMaster === true);
+}
+
+export async function reanchorReusedSession(session, identity, persist = null) {
+  Object.assign(session, {
+    authenticated: true,
+    keyId: identity.keyId ?? null,
+    groupKeyIds: identity.groupKeyIds ?? null,
+    permissions: identity.permissions ?? null,
+    defaultWorkspace: identity.defaultWorkspace ?? null,
+    mode: identity.mode ?? null,
+    isMaster: identity.isMaster === true
+  });
+  if (persist) {
+    const persisted = await persist(session);
+    if (persisted !== true) throw new Error("Reused session persistence failed");
+  }
+  return session;
 }
 
 /**
@@ -161,9 +186,9 @@ async function _resolveExistingSession(req, res, sessionId, msg) {
         /** keyId 교차 검증: Redis에 기존 세션이 있으면 keyId 일치 확인 */
         if (REDIS_ENABLED) {
           const existingRedis = await getSessionFromRedis(sessionId);
-          if (existingRedis && existingRedis.keyId !== incomingKeyId) {
-            recordTenantIsolationBlocked("session_recover_keyid_mismatch");
-            recordSessionRecovery("keyid_mismatch");
+          if (hasSessionIdentityMismatch(existingRedis, authResult)) {
+            recordTenantIsolationBlocked("session_recover_identity_mismatch");
+            recordSessionRecovery("identity_mismatch");
             await sendJSON(res, 403, jsonRpcError(null, -32000, "Forbidden"), req);
             return { done: true };
           }
@@ -212,6 +237,12 @@ async function _resolveExistingSession(req, res, sessionId, msg) {
       return { done: true };
     }
   } else {
+    /**
+     * MCP 세션 ID를 수명 내 인증 capability로 취급한다. 유효 세션의 매 요청마다
+     * bearer를 재검증하면 토큰 갱신/헤더 생략을 허용하는 기존 MCP 클라이언트를
+     * 깨뜨리므로, 저장된 서버 측 identity를 사용한다. 세션 복구와 rotate는 별도로
+     * 현재 credential을 재검증하고 identity 일치를 확인한다.
+     */
     const session               = validation.session;
     let sessionKeyId            = session.keyId ?? null;
     let sessionGroupKeyIds      = session.groupKeyIds ?? null;
@@ -259,7 +290,7 @@ async function _resolveExistingSession(req, res, sessionId, msg) {
           delete persistable._restoredFromRedis;
           await saveSessionToRedis(sessionId, persistable, Math.ceil(SESSION_TTL_MS / 1000));
         }
-        logInfo(`[Session] Refetched groupKeyIds for stale session ${sessionId}`);
+        logInfo(`[Session] Refetched group membership for stale session ${sessionId}`);
       }
     }
 
@@ -325,26 +356,24 @@ async function _createInitializeSession(req, res, msg) {
       if (validation.valid) {
         sessionId = existingSid;
         reusedExisting = true;
-        /** 배포 전 세션을 포함해 현재 인증 결과로 권한 컨텍스트를 재앵커링한다. */
-        Object.assign(validation.session, {
-          authenticated: true,
+        await reanchorReusedSession(validation.session, {
           keyId: sessionKeyId,
           groupKeyIds: sessionGroupKeyIds,
           permissions: sessionPermissions,
           defaultWorkspace: sessionDefaultWorkspace,
           mode: sessionMode,
           isMaster: sessionIsMaster
-        });
-        if (REDIS_ENABLED) {
-          const persistable = { ...validation.session };
-          delete persistable.getSseResponse;
-          delete persistable.setSseResponse;
-          delete persistable.close;
-          delete persistable._restoredFromRedis;
-          await saveSessionToRedis(
-            sessionId, persistable, Math.ceil(SESSION_TTL_MS / 1000)
-          );
-        }
+        }, REDIS_ENABLED ? async session => {
+            const persistable = { ...session };
+            delete persistable.getSseResponse;
+            delete persistable.setSseResponse;
+            delete persistable.close;
+            delete persistable._restoredFromRedis;
+            const remainingTtlSec = Math.max(
+              Math.ceil((session.expiresAt - Date.now()) / 1000), 60
+            );
+            return saveSessionToRedis(sessionId, persistable, remainingTtlSec);
+          } : null);
         recordSessionRecovery("token_matched");
         logInfo(`[Streamable] Session reused by token: ${sessionId}`);
       }
@@ -424,8 +453,24 @@ async function _validateProtocolVersion(req, res, msg, sessionId) {
  * @param {string|null} sessionMode
  * @param {bigint}      startTime
  */
-async function _dispatchAndRespond(req, res, msg, sessionId, sessionKeyId, sessionMode, startTime) {
-  const { kind, response } = await dispatchJsonRpc(msg, { keyId: sessionKeyId, mode: sessionMode });
+async function _dispatchAndRespond(
+  req, res, msg, sessionId, sessionKeyId, sessionMode, startTime, authContext = {}
+) {
+  const trustedSessionId = msg.method === "resources/read"
+    ? await peekCurrentSegmentId(sessionId)
+    : sessionId;
+  const { kind, response } = await dispatchJsonRpc(msg, {
+    authenticated   : true,
+    keyId           : sessionKeyId,
+    groupKeyIds     : authContext.groupKeyIds ?? null,
+    permissions     : authContext.permissions ?? null,
+    isMaster        : authContext.isMaster === true,
+    defaultWorkspace: authContext.defaultWorkspace ?? null,
+    mode            : sessionMode,
+    sessionId: trustedSessionId,
+    clientIp        : req?.socket?.remoteAddress ?? "unknown",
+    userAgent       : req?.headers?.["user-agent"] ?? "unknown"
+  });
 
   /**
    * 2c-3 / 계약 R3: initialize 응답에서 negotiatedVersion을 세션에 저장하고,
@@ -502,8 +547,8 @@ export async function handleMcpPost(req, res, startTime, rateLimiter) {
   let sessionGroupKeyIds    = null;
   let sessionPermissions    = null;
   let sessionDefaultWorkspace = null;
-  let sessionIsMaster = false;
   let sessionMode           = null;
+  let sessionIsMaster       = false;
   let msg;
 
   try {
@@ -531,7 +576,7 @@ export async function handleMcpPost(req, res, startTime, rateLimiter) {
     sessionPermissions      = result.sessionPermissions;
     sessionDefaultWorkspace = result.sessionDefaultWorkspace;
     sessionMode             = result.sessionMode;
-    sessionIsMaster         = result.sessionIsMaster;
+    sessionIsMaster         = result.sessionIsMaster === true;
   }
 
   /**
@@ -555,7 +600,7 @@ export async function handleMcpPost(req, res, startTime, rateLimiter) {
     sessionPermissions      = result.sessionPermissions;
     sessionDefaultWorkspace = result.sessionDefaultWorkspace;
     sessionMode             = result.sessionMode;
-    sessionIsMaster         = result.sessionIsMaster;
+    sessionIsMaster         = result.sessionIsMaster === true;
   }
 
   if (!sessionId) {
@@ -584,18 +629,11 @@ export async function handleMcpPost(req, res, startTime, rateLimiter) {
     sessionGroupKeyIds,
     sessionPermissions,
     sessionDefaultWorkspace,
-    sessionIsMaster,
     sessionMode,
+    sessionIsMaster,
     clientIp,
     userAgent: req.headers["user-agent"] || "unknown"
   });
-
-  if (msg.method === "resources/read" && msg.params) {
-    msg.params._keyId       = sessionKeyId;
-    msg.params._groupKeyIds = sessionGroupKeyIds;
-    /** 조회 전용이므로 세그먼트 회전을 유발하지 않는 peek을 사용한다. */
-    msg.params._sessionId   = await peekCurrentSegmentId(sessionId);
-  }
 
   /** 2c-3: MCP-Protocol-Version 헤더 검증
    *
@@ -612,7 +650,15 @@ export async function handleMcpPost(req, res, startTime, rateLimiter) {
    * batch_remember / memory_consolidate 포함 모든 도구는 _dispatchAndRespond로 통일된다.
    * stream 파라미터는 하위 호환 유지 목적으로만 존재하며 동작에 영향을 주지 않는다.
    */
-  await _dispatchAndRespond(req, res, msg, sessionId, sessionKeyId, sessionMode, startTime);
+  await _dispatchAndRespond(
+    req, res, msg, sessionId, sessionKeyId, sessionMode, startTime,
+    {
+      groupKeyIds: sessionGroupKeyIds,
+      permissions: sessionPermissions,
+      defaultWorkspace: sessionDefaultWorkspace,
+      isMaster: sessionIsMaster
+    }
+  );
 }
 
 /**
@@ -716,10 +762,11 @@ export async function handleMcpDelete(req, res) {
     return;
   }
 
-  /** keyId 비교 — master key(keyId=null)는 모든 세션 종료 허용 */
+  /** explicit master만 모든 세션 종료 허용. keyId=null OAuth는 master가 아니다. */
   const sessionKeyId   = validation.session.keyId ?? null;
   const requesterKeyId = authResult.keyId ?? null;
-  if (requesterKeyId !== null && requesterKeyId !== sessionKeyId) {
+  if (authResult.isMaster !== true &&
+      (requesterKeyId === null || requesterKeyId !== sessionKeyId)) {
     recordTenantIsolationBlocked("session_delete");
     res.statusCode = 403;
     res.setHeader("Content-Type", "application/json; charset=utf-8");
@@ -771,7 +818,11 @@ function _resolveMode(req, msg, dbDefaultMode, _keyId) {
  * 테스트 전용: tools/call 메시지를 표준 응답 경로로 처리한다.
  * 운영 경로(handleMcpPost)와 동일하게 _dispatchAndRespond로 위임한다.
  */
-export async function handleToolCallForTest(req, res, msg, sessionId, sessionKeyId, sessionMode) {
+export async function handleToolCallForTest(
+  req, res, msg, sessionId, sessionKeyId, sessionMode, authContext = {}
+) {
   const startTime = process.hrtime.bigint();
-  await _dispatchAndRespond(req, res, msg, sessionId, sessionKeyId, sessionMode, startTime);
+  await _dispatchAndRespond(
+    req, res, msg, sessionId, sessionKeyId, sessionMode, startTime, authContext
+  );
 }

--- a/lib/handlers/session-handler.js
+++ b/lib/handlers/session-handler.js
@@ -118,10 +118,18 @@ export async function handleSessionRotate(req, res) {
     /** 본문 없거나 파싱 실패 시 기본값 유지 */
   }
 
-  logInfo(`[Session/Rotate] sessionId=${sessionId.slice(0, 8)}... keyId=${auth.keyId ?? "master"} reason=${reason}`);
+  logInfo(`[Session/Rotate] sessionId=${sessionId.slice(0, 8)}... request accepted`);
 
   try {
-    const result = await rotateSession(sessionId, { reason });
+    const result = await rotateSession(sessionId, {
+      reason,
+      requesterIdentity: {
+        keyId: auth.keyId ?? null,
+        isMaster: auth.isMaster === true,
+        groupKeyIds: auth.groupKeyIds ?? null,
+        permissions: auth.permissions ?? null
+      }
+    });
     await sendJSON(res, 200, {
       oldSessionId: result.oldSessionId,
       newSessionId: result.newSessionId,
@@ -138,6 +146,16 @@ export async function handleSessionRotate(req, res) {
 
     if (statusCode === 401) {
       await sendJSON(res, 401, { error: "session_expired", error_description: "Session has expired" }, req);
+      return;
+    }
+
+    if (statusCode === 403) {
+      await sendJSON(res, 403, { error: "forbidden", error_description: "Session identity mismatch" }, req);
+      return;
+    }
+
+    if (statusCode === 503) {
+      await sendJSON(res, 503, { error: "temporarily_unavailable", error_description: "Session persistence unavailable" }, req);
       return;
     }
 

--- a/lib/handlers/sse-handler.js
+++ b/lib/handlers/sse-handler.js
@@ -5,7 +5,7 @@
  * 작성일: 2026-04-04
  */
 
-import { ACCESS_KEY } from "../config.js";
+import { ACCESS_KEY, AUTH_DISABLED } from "../config.js";
 import { readJsonBody, sseWrite } from "../utils.js";
 import { injectSessionContext } from "./mcp-handler.js";
 import {
@@ -18,6 +18,10 @@ import { validateAuthentication, safeCompare } from "../auth.js";
 import { getGroupKeyIds } from "../admin/ApiKeyStore.js";
 import { logInfo, logWarn } from "../logger.js";
 import { dispatchJsonRpc } from "../jsonrpc.js";
+
+export function isLegacySseAuthDisabledMaster(accessKey, authDisabled) {
+  return !accessKey && authDisabled === true;
+}
 
 /**
  * GET /sse (Legacy SSE)
@@ -33,25 +37,30 @@ export async function handleLegacySseGet(req, res) {
   let defaultWorkspace = null;
   let isMaster         = false;
 
-  /** 1. Authorization Bearer 헤더 우선. ACCESS_KEY 부재도 공통 fail-closed 정책을 따른다. */
-  const authResult = await validateAuthentication(req, null);
-  if (authResult.valid) {
-    isAuthenticated  = true;
-    keyId            = authResult.keyId || null;
-    groupKeyIds      = authResult.groupKeyIds ?? null;
-    permissions      = authResult.permissions ?? null;
-    defaultWorkspace = authResult.defaultWorkspace ?? null;
-    isMaster         = authResult.isMaster === true;
-  } else if (ACCESS_KEY) {
-    /** 2. 쿼리스트링 fallback (하위 호환) — safeCompare 적용 */
-    const rawKey    = url.searchParams.get("accessKey") || "";
-    let accessKey   = rawKey;
-    try { accessKey = decodeURIComponent(rawKey); } catch { /* 디코딩 실패 시 원본 사용 */ }
+  if (isLegacySseAuthDisabledMaster(ACCESS_KEY, AUTH_DISABLED)) {
+    isAuthenticated = true;
+    isMaster        = true;
+  } else {
+    /** 1. Authorization Bearer 헤더 우선 */
+    const authResult = await validateAuthentication(req, null);
+    if (authResult.valid) {
+      isAuthenticated  = true;
+      keyId            = authResult.keyId || null;
+      groupKeyIds      = authResult.groupKeyIds ?? null;
+      permissions      = authResult.permissions ?? null;
+      defaultWorkspace = authResult.defaultWorkspace ?? null;
+      isMaster         = authResult.isMaster === true;
+    } else {
+      /** 2. 쿼리스트링 fallback (하위 호환) — safeCompare 적용 */
+      const rawKey    = url.searchParams.get("accessKey") || "";
+      let accessKey   = rawKey;
+      try { accessKey = decodeURIComponent(rawKey); } catch { /* 디코딩 실패 시 원본 사용 */ }
 
-    if (accessKey && safeCompare(accessKey, ACCESS_KEY)) {
-      isAuthenticated = true;
-      isMaster        = true;
-      logWarn("[Legacy SSE] Query string authentication used. Prefer Authorization header.");
+      if (accessKey && safeCompare(accessKey, ACCESS_KEY)) {
+        isAuthenticated = true;
+        isMaster        = true;
+        logWarn("[Legacy SSE] Query string authentication used. Prefer Authorization header.");
+      }
     }
   }
 
@@ -135,7 +144,7 @@ export async function handleLegacySsePost(req, res) {
     const refetched = await getGroupKeyIds(session._keyId);
     if (refetched) {
       session._groupKeyIds = refetched;
-      logInfo(`[Legacy SSE] Refetched groupKeyIds for stale session ${sessionId}`);
+      logInfo(`[Legacy SSE] Refetched group membership for stale session ${sessionId}`);
     }
   }
 
@@ -146,10 +155,21 @@ export async function handleLegacySsePost(req, res) {
     sessionGroupKeyIds:    session._groupKeyIds ?? null,
     sessionPermissions:    session._permissions ?? null,
     sessionDefaultWorkspace: session._defaultWorkspace ?? null,
-    sessionIsMaster:        session._isMaster === true
+    sessionIsMaster:       session._isMaster === true
   });
 
-  const { kind, response } = await dispatchJsonRpc(msg, { keyId: session._keyId ?? null });
+  const { kind, response } = await dispatchJsonRpc(msg, {
+    authenticated   : true,
+    keyId           : session._keyId ?? null,
+    groupKeyIds     : session._groupKeyIds ?? null,
+    permissions     : session._permissions ?? null,
+    isMaster        : session._isMaster === true,
+    defaultWorkspace: session._defaultWorkspace ?? null,
+    mode            : session._mode ?? null,
+    sessionId,
+    clientIp        : req?.socket?.remoteAddress ?? "unknown",
+    userAgent       : req?.headers?.["user-agent"] ?? "unknown"
+  });
 
   if (kind === "ok" || kind === "error") {
     sseWrite(session.res, "message", response);

--- a/lib/jsonrpc.js
+++ b/lib/jsonrpc.js
@@ -27,6 +27,7 @@ import {
 } from "./metrics.js";
 import { logInfo, logError } from "./logger.js";
 import { checkPermission }   from "./rbac.js";
+import { assertAuthenticatedAgentScope, assertMasterPeerScope } from "./memory/read/AgentScope.js";
 
 /**
  * JSON-RPC 에러 응답 생성
@@ -115,7 +116,7 @@ function negotiateProtocolVersion(clientVersion) {
 /**
  * initialize 핸들러
  */
-export async function handleInitialize(params) {
+export async function handleInitialize(params, sessionData = null) {
   const startTime        = process.hrtime.bigint();
 
   try {
@@ -217,10 +218,10 @@ export async function handleInitialize(params) {
 단계 2 — 도구 호출 공통 형식:
   curl -s -X POST $SERVER_URL -H "Content-Type: application/json" -H "Authorization: Bearer $ACCESS_KEY" -H "MCP-Session-Id: $SESSION_ID" -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"TOOL","arguments":{ARGS}}}'
 
-reflect: name="reflect", arguments={"agentId":"ID","summary":["요약1"],"decisions":["결정"],"keywords":["프로젝트명"]}
-remember: name="remember", arguments={"agentId":"ID","content":"내용","type":"fact","importance":0.7,"keywords":["키워드"]}
-recall:   name="recall",   arguments={"agentId":"ID","query":"검색어"}
-context:  name="context",  arguments={"agentId":"ID","structured":true}
+reflect: name="reflect", arguments={"agentId":"default","summary":["요약1"],"decisions":["결정"],"keywords":["프로젝트명"]}
+remember: name="remember", arguments={"agentId":"default","content":"내용","type":"fact","importance":0.7,"keywords":["키워드"]}
+recall:   name="recall",   arguments={"agentId":"default","query":"검색어"}
+context:  name="context",  arguments={"agentId":"default","structured":true}
 
 응답 파싱: 끝에 | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['result']['content'][0]['text'])" 추가.
 
@@ -288,7 +289,7 @@ context:  name="context",  arguments={"agentId":"ID","structured":true}
 프로토콜 버전: ${negotiatedVersion}
 지원 버전: ${SUPPORTED_PROTOCOL_VERSIONS.join(", ")}`;
 
-    const toolCount = getToolsDefinition(null).length;
+    const toolCount = getSessionTools(sessionData).length;
     const result = {
       protocolVersion: negotiatedVersion,
       serverInfo     : {
@@ -337,15 +338,20 @@ context:  name="context",  arguments={"agentId":"ID","structured":true}
 /**
  * tools/list 핸들러
  */
+function getSessionTools(sessionData) {
+  const keyId = sessionData?.keyId ?? null;
+  const mode = sessionData?.mode ?? null;
+  const isMaster = sessionData?.isMaster === true;
+  return filterTools(getToolsDefinition(keyId, isMaster), mode, isMaster).filter(tool =>
+    isMaster || TOOL_REGISTRY.get(tool.name)?.meta?.requiresMaster !== true
+  );
+}
+
 export function handleToolsList(_params, sessionData) {
   const startTime        = process.hrtime.bigint();
 
   try {
-    const keyId          = sessionData?.keyId ?? null;
-    const mode           = sessionData?.mode  ?? null;
-    const isMaster       = keyId === null;
-    const allTools       = getToolsDefinition(keyId);
-    const tools          = filterTools(allTools, mode, isMaster);
+    const tools = getSessionTools(sessionData);
 
     const result = { tools };
 
@@ -364,7 +370,58 @@ export function handleToolsList(_params, sessionData) {
 /**
  * tools/call 핸들러
  */
-export async function handleToolsCall(params) {
+export function applyTrustedToolContext(params, sessionData) {
+  const requiredContext = [
+    "keyId", "groupKeyIds", "permissions", "defaultWorkspace", "mode", "sessionId", "isMaster"
+  ];
+  const trusted = sessionData?.authenticated === true && requiredContext.every(key =>
+    Object.prototype.hasOwnProperty.call(sessionData, key)
+  );
+  if (!trusted) {
+    const error = new Error("Authenticated session context required");
+    error.code = -32600;
+    throw error;
+  }
+
+  const explicitMaster = sessionData.isMaster === true;
+  const identityConsistent = explicitMaster
+    ? sessionData.keyId == null && sessionData.permissions == null
+    : sessionData.keyId != null && Array.isArray(sessionData.permissions);
+  if (!identityConsistent) {
+    const message = explicitMaster
+      ? "Authenticated master session has inconsistent identity context"
+      : sessionData.keyId == null
+        ? "Authenticated non-master session requires an API-key binding; OAuth sessions must be bound to an API key"
+        : "Authenticated non-master session requires an API-key permission context";
+    const error = new Error(message);
+    error.code = -32001;
+    throw error;
+  }
+
+  if (params.arguments === undefined) params.arguments = {};
+  const args = params.arguments;
+  if (args === null || typeof args !== "object" || Array.isArray(args)) {
+    const error = new Error("Tool arguments must be an object");
+    error.code = -32602;
+    throw error;
+  }
+  for (const key of [
+    "_keyId", "_groupKeyIds", "_permissions", "_defaultWorkspace", "_mode",
+    "_sessionId", "_clientIp", "_userAgent", "_isMaster"
+  ]) delete args[key];
+  args._keyId             = sessionData.keyId ?? null;
+  args._groupKeyIds       = sessionData.groupKeyIds ?? null;
+  args._permissions       = sessionData.permissions ?? null;
+  args._defaultWorkspace  = sessionData.defaultWorkspace ?? null;
+  args._mode              = sessionData.mode ?? null;
+  args._sessionId         = sessionData.sessionId ?? null;
+  args._clientIp          = sessionData.clientIp ?? "unknown";
+  args._userAgent         = sessionData.userAgent ?? "unknown";
+  args._isMaster          = sessionData.isMaster === true;
+  return args;
+}
+
+export async function handleToolsCall(params, sessionData = null) {
   const startTime        = process.hrtime.bigint();
 
   if (!params || typeof params.name !== "string") {
@@ -372,7 +429,7 @@ export async function handleToolsCall(params) {
   }
 
   const name             = params.name;
-  const args             = params.arguments || {};
+  const args             = applyTrustedToolContext(params, sessionData);
 
   const entry            = TOOL_REGISTRY.get(name);
 
@@ -382,13 +439,40 @@ export async function handleToolsCall(params) {
     throw error;
   }
 
-  /** RBAC 권한 검증 — _permissions가 null이면 master key (전체 허용) */
-  const { allowed, required } = checkPermission(args._permissions ?? null, name);
+  if (entry.meta?.requiresMaster === true && args._isMaster !== true) {
+    recordRbacDenied(name, "requires_master");
+    const error = new Error(`Permission denied: '${name}' requires master authentication`);
+    error.code = -32001;
+    throw error;
+  }
+
+  /** null permissions는 explicit master에서만 전체 허용한다. */
+  if (args._isMaster !== true && !Array.isArray(args._permissions)) {
+    const error = new Error("Permission context required for non-master session");
+    error.code = -32001;
+    throw error;
+  }
+  const permissionContext = args._isMaster === true ? null : args._permissions;
+  const { allowed, required } = checkPermission(permissionContext, name, args._isMaster === true);
   if (!allowed) {
     recordRbacDenied(name, `requires_${required}`);
     const error          = new Error(`Permission denied: '${name}' requires '${required}' permission`);
-    error.code           = -32600;
+    error.code           = -32001;
     throw error;
+  }
+
+  /** 동적 범위 권한: peer-agent 조회는 서버가 주입한 master key 컨텍스트만 허용한다. */
+  try {
+    assertMasterPeerScope(args);
+    assertAuthenticatedAgentScope(args);
+  } catch (err) {
+    if (err.code === "INVALID_PARAMS") {
+      err.code = -32602;
+      throw err;
+    }
+    recordRbacDenied(name, "requires_master_peer_scope");
+    err.code = -32001;
+    throw err;
   }
 
   const toolResult       = await entry.handler(args);
@@ -510,15 +594,33 @@ export function handleResourcesList(_params) {
 /**
  * resources/read 핸들러
  */
-export async function handleResourcesRead(params) {
+export async function handleResourcesRead(params, sessionData = null) {
   const startTime        = process.hrtime.bigint();
 
   if (!params || typeof params.uri !== "string") {
     throw new Error("Resource URI is required");
   }
 
+  const trustedParams = applyTrustedToolContext({ arguments: params }, sessionData);
+  const isMaster = trustedParams._isMaster === true;
+  const permission = checkPermission(
+    isMaster ? null : trustedParams._permissions, "recall", isMaster
+  );
+  if (!permission.allowed) {
+    const error = new Error("Resource read permission denied");
+    error.code = -32001;
+    throw error;
+  }
   try {
-    const result = await readResourceContent(params.uri, params);
+    assertMasterPeerScope(trustedParams);
+    assertAuthenticatedAgentScope(trustedParams);
+  } catch (err) {
+    err.code = err.code === "INVALID_PARAMS" ? -32602 : -32001;
+    throw err;
+  }
+
+  try {
+    const result = await readResourceContent(trustedParams.uri, trustedParams);
 
     const duration = Number(process.hrtime.bigint() - startTime) / 1e9;
     recordRpcMethod("resources/read", true, duration);
@@ -534,7 +636,7 @@ export async function handleResourcesRead(params) {
 /**
  * JSON-RPC 요청 디스패처
  */
-export async function dispatchJsonRpc(msg, sessionData = {}) {
+export async function dispatchJsonRpc(msg, sessionData = null) {
   if (!msg || typeof msg !== "object") {
     return { kind: "error", response: jsonRpcError(null, -32600, "Invalid Request") };
   }
@@ -554,15 +656,15 @@ export async function dispatchJsonRpc(msg, sessionData = {}) {
 
   const isNotification       = id === undefined;
 
-  /** method → handler 맵. tools/list만 sessionData를 추가 인자로 받는다. */
+  /** method → handler 맵. 세션 범위가 필요한 핸들러에 인증 문맥을 전달한다. */
   const METHOD_MAP = {
-    "initialize"      : () => handleInitialize(params),
+    "initialize"      : () => handleInitialize(params, sessionData),
     "tools/list"      : () => handleToolsList(params, sessionData),
-    "tools/call"      : () => handleToolsCall(params),
+    "tools/call"      : () => handleToolsCall(params, sessionData),
     "prompts/list"    : () => handlePromptsList(params),
     "prompts/get"     : () => handlePromptsGet(params),
     "resources/list"  : () => handleResourcesList(params),
-    "resources/read"  : () => handleResourcesRead(params),
+    "resources/read"  : () => handleResourcesRead(params, sessionData),
   };
 
   try {
@@ -613,7 +715,10 @@ export async function dispatchJsonRpc(msg, sessionData = {}) {
 
     logError(`[ERROR] ${method}:`, err);
     const errorCode        = err.code || -32603;
-    const errorMessage     = (errorCode === -32601 || errorCode === -32602) ? err.message : "Internal error";
+    /** -32001은 인증/권한 전용 안전 메시지다. 내부 예외(-32603)는 계속 숨긴다. */
+    const errorMessage     = [-32601, -32602, -32001].includes(errorCode)
+      ? err.message
+      : "Internal error";
 
     // 에러 메트릭 기록
     recordError(method, errorCode);

--- a/lib/logging/audit.js
+++ b/lib/logging/audit.js
@@ -10,20 +10,30 @@ import path                 from "path";
 import { LOG_DIR }          from "../config.js";
 import { logError }         from "../logger.js";
 
+function auditField(value) {
+  return value == null ? "" : String(value).replace(/[\r\n|;]/g, " ");
+}
+
 /**
  * 감사 로그 기록 (기억 도구 상태 변경 작업 추적)
  * 형식: timestamp | operation | topic | type | fragmentId | success | details
  */
-export async function logAudit(operation, { topic, type, fragmentId, success, details } = {}) {
+export async function logAudit(operation, {
+  topic, type, fragmentId, success, details, agentScope, includePeerAgents
+} = {}) {
   const timestamp          = new Date().toISOString();
   const logEntry           = `${[
     timestamp,
     operation,
-    topic      || "-",
-    type       || "-",
-    fragmentId || "-",
+    auditField(topic)      || "-",
+    auditField(type)       || "-",
+    auditField(fragmentId) || "-",
     success    === false ? "FAIL" : "OK",
-    details    || ""
+    [
+      auditField(details),
+      agentScope ? `agent_scope=${auditField(agentScope)}` : "",
+      includePeerAgents !== undefined ? `peer=${includePeerAgents === true}` : ""
+    ].filter(Boolean).join("; ")
   ].join(" | ")  }\n`;
 
   try {

--- a/lib/memory/CaseEventStore.js
+++ b/lib/memory/CaseEventStore.js
@@ -9,7 +9,7 @@ import { getPrimaryPool, withTransaction } from "../tools/db.js";
 import { buildSearchPath } from "../config.js";
 import { logWarn }         from "../logger.js";
 import { getBackprop }     from "./signals/CaseRewardBackprop.js";
-import { keyScopeCondition, keyScopeScalar } from "./keyScope.js";
+import { keyScopeCondition, keyScopeNullable, keyScopeScalar } from "./keyScope.js";
 import { SCHEMA } from "./schema.js";
 
 export class CaseEventStore {
@@ -55,11 +55,28 @@ export class CaseEventStore {
       );
       const seqNo = seqResult.rows[0].next_seq;
 
+      let snapshot = { agent_id: null, workspace: null };
+      if (event.source_fragment_id) {
+        const sourceParams = [event.source_fragment_id];
+        const sourceKeyClause = keyScopeNullable(
+          sourceParams, "key_id", event.key_id ?? null
+        ).trimStart();
+        const scopeResult = await client.query(
+          `SELECT agent_id, workspace
+             FROM ${SCHEMA}.fragments
+            WHERE id = $1
+              ${sourceKeyClause}`,
+          sourceParams
+        );
+        snapshot = scopeResult.rows[0] ?? snapshot;
+      }
+
       return client.query(
         `INSERT INTO ${SCHEMA}.case_events
                 (case_id, session_id, sequence_no, event_type, summary,
-                 entity_keys, source_fragment_id, source_search_event_id, key_id)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                 entity_keys, source_fragment_id, source_search_event_id, key_id,
+                 agent_id, workspace)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
          RETURNING event_id, sequence_no`,
         [
           event.case_id,
@@ -70,7 +87,9 @@ export class CaseEventStore {
           event.entity_keys            ?? [],
           event.source_fragment_id     ?? null,
           event.source_search_event_id ?? null,
-          event.key_id                 ?? null
+          event.key_id                 ?? null,
+          snapshot.agent_id            ?? null,
+          snapshot.workspace           ?? null
         ]
       );
     });

--- a/lib/memory/CaseEventStore.js
+++ b/lib/memory/CaseEventStore.js
@@ -9,8 +9,23 @@ import { getPrimaryPool, withTransaction } from "../tools/db.js";
 import { buildSearchPath } from "../config.js";
 import { logWarn }         from "../logger.js";
 import { getBackprop }     from "./signals/CaseRewardBackprop.js";
-import { keyScopeCondition, keyScopeNullable, keyScopeScalar } from "./keyScope.js";
+import { keyScopeClause, keyScopeCondition, keyScopeNullable, keyScopeScalar } from "./keyScope.js";
 import { SCHEMA } from "./schema.js";
+import { agentScopeCondition, resolveAgentScope } from "./read/AgentScope.js";
+import { resolveWorkspaceScope } from "./read/WorkspaceScope.js";
+
+function appendWorkspaceScope(params, clauses, opts, columns) {
+  const scope = resolveWorkspaceScope(opts);
+  if (scope.allWorkspaces) return;
+  if (scope.workspace === null) {
+    for (const column of columns) clauses.push(`${column} IS NULL`);
+    return;
+  }
+  params.push(scope.workspace);
+  for (const column of columns) {
+    clauses.push(`(${column} = $${params.length} OR ${column} IS NULL)`);
+  }
+}
 
 export class CaseEventStore {
   /**
@@ -69,6 +84,13 @@ export class CaseEventStore {
           sourceParams
         );
         snapshot = scopeResult.rows[0] ?? snapshot;
+      }
+      if (snapshot.agent_id === null || snapshot.agent_id === undefined) {
+        // Do not log identifiers, keys, summaries, or raw database errors.
+        // NULL is quarantined from scoped reads; never invent a shared scope.
+        logWarn(event.source_fragment_id
+          ? "[CaseEventStore] event scope snapshot unavailable: source missing, key mismatch, or not committed; storing NULL scope"
+          : "[CaseEventStore] event scope snapshot unavailable: source-less event; storing NULL scope");
       }
 
       return client.query(
@@ -170,6 +192,8 @@ export class CaseEventStore {
     const limit     = Math.min(opts.limit ?? 100, 500);
     const keyId     = opts.keyId     ?? null;
     const eventType = opts.eventType ?? null;
+    const enforceSnapshotScope = opts.agentId !== undefined;
+    const eventAlias = "ce.";
 
     const params  = [caseId];
     const clauses = [];
@@ -177,22 +201,33 @@ export class CaseEventStore {
     /** 시간 범위 */
     if (opts.from) {
       params.push(opts.from);
-      clauses.push(`created_at >= $${params.length}::timestamptz`);
+      clauses.push(`${eventAlias}created_at >= $${params.length}::timestamptz`);
     }
     if (opts.to) {
       params.push(opts.to);
-      clauses.push(`created_at <= $${params.length}::timestamptz`);
+      clauses.push(`${eventAlias}created_at <= $${params.length}::timestamptz`);
     }
 
     /** event_type 필터 */
     if (eventType) {
       params.push(eventType);
-      clauses.push(`event_type = $${params.length}`);
+      clauses.push(`${eventAlias}event_type = $${params.length}`);
     }
 
     /** key_id 격리 */
-    const keyCond = keyScopeCondition(params, "key_id", keyId);
-    if (keyCond) clauses.push(keyCond);
+    if (enforceSnapshotScope) {
+      const agentScope = resolveAgentScope(opts);
+      params.push(agentScope.agentId);
+      clauses.push(agentScopeCondition(`$${params.length}`, agentScope, "ce.agent_id"));
+      const eventKey = keyScopeClause(params, "ce.key_id", {
+        keyId, groupKeyIds: opts.groupKeyIds
+      });
+      if (eventKey) clauses.push(eventKey.trim().replace(/^AND\s+/, ""));
+      appendWorkspaceScope(params, clauses, opts, ["ce.workspace"]);
+    } else {
+      const keyCond = keyScopeCondition(params, "ce.key_id", keyId);
+      if (keyCond) clauses.push(keyCond);
+    }
 
     /** limit */
     params.push(limit);
@@ -201,13 +236,15 @@ export class CaseEventStore {
     const whereExtra = clauses.length > 0 ? `AND ${clauses.join(" AND ")}` : "";
 
     const sql = `
-      SELECT event_id, case_id, session_id, sequence_no, event_type,
-             summary, entity_keys, source_fragment_id, source_search_event_id,
-             key_id, created_at
-        FROM ${SCHEMA}.case_events
-       WHERE case_id = $1
+      SELECT ${eventAlias}event_id, ${eventAlias}case_id, ${eventAlias}session_id,
+             ${eventAlias}sequence_no, ${eventAlias}event_type,
+             ${eventAlias}summary, ${eventAlias}entity_keys, ${eventAlias}source_fragment_id,
+             ${eventAlias}source_search_event_id, ${eventAlias}key_id,
+             ${eventAlias}agent_id, ${eventAlias}workspace, ${eventAlias}created_at
+        FROM ${SCHEMA}.case_events ce
+       WHERE ${eventAlias}case_id = $1
          ${whereExtra}
-       ORDER BY created_at ASC, sequence_no ASC
+       ORDER BY ${eventAlias}created_at ASC, ${eventAlias}sequence_no ASC
        LIMIT $${limitIdx}`;
 
     const { rows } = await pool.query(sql, params);
@@ -230,18 +267,32 @@ export class CaseEventStore {
     const limit = Math.min(opts.limit ?? 50, 500);
     const keyId = opts.keyId ?? null;
 
-    const params    = [sessionId];
-    const keyFilter = keyScopeScalar(params, "key_id", keyId).trimStart();
+    const params = [sessionId];
+    const clauses = [];
+    if (opts.agentId !== undefined) {
+      const agentScope = resolveAgentScope(opts);
+      params.push(agentScope.agentId);
+      clauses.push(agentScopeCondition(`$${params.length}`, agentScope, "agent_id"));
+      const keyClause = keyScopeClause(params, "key_id", {
+        keyId, groupKeyIds: opts.groupKeyIds
+      });
+      if (keyClause) clauses.push(keyClause.trim().replace(/^AND\s+/, ""));
+      appendWorkspaceScope(params, clauses, opts, ["workspace"]);
+    } else {
+      const keyClause = keyScopeScalar(params, "key_id", keyId);
+      if (keyClause) clauses.push(keyClause.trim().replace(/^AND\s+/, ""));
+    }
+    const scopeClause = clauses.length > 0 ? `AND ${clauses.join(" AND ")}` : "";
     params.push(limit);
     const limitIdx = params.length;
 
     const { rows } = await pool.query(
       `SELECT event_id, case_id, session_id, sequence_no, event_type,
               summary, entity_keys, source_fragment_id, source_search_event_id,
-              key_id, created_at
+              key_id, agent_id, workspace, created_at
          FROM ${SCHEMA}.case_events
         WHERE session_id = $1
-          ${keyFilter}
+          ${scopeClause}
         ORDER BY created_at ASC, sequence_no ASC
         LIMIT $${limitIdx}`,
       params
@@ -257,33 +308,44 @@ export class CaseEventStore {
    * @param {number|null} [keyId=null] - API 키 격리 필터
    * @returns {Promise<Object[]>}
    */
-  async getEdgesByEvents(eventIds, keyId = null) {
+  async getEdgesByEvents(eventIds, keyOrOpts = null) {
     if (!eventIds || eventIds.length === 0) return [];
 
     const pool = getPrimaryPool();
     if (!pool) return [];
 
-    if (keyId != null) {
-      /** key_id 격리: case_events JOIN으로 from/to 양쪽 모두 해당 키 소유인 엣지만 반환 */
-      const { rows } = await pool.query(
-        `SELECT ee.from_event_id, ee.to_event_id, ee.edge_type, ee.confidence
-           FROM ${SCHEMA}.case_event_edges ee
-           JOIN ${SCHEMA}.case_events ce_from ON ce_from.event_id = ee.from_event_id
-           JOIN ${SCHEMA}.case_events ce_to   ON ce_to.event_id   = ee.to_event_id
-          WHERE (ee.from_event_id = ANY($1::uuid[]) OR ee.to_event_id = ANY($1::uuid[]))
-            AND ce_from.key_id = $2
-            AND ce_to.key_id   = $2`,
-        [eventIds, keyId]
-      );
-      return rows;
+    const opts = keyOrOpts && typeof keyOrOpts === "object"
+      ? keyOrOpts
+      : { keyId: keyOrOpts };
+    const params = [eventIds];
+    const clauses = [];
+    if (opts.agentId !== undefined) {
+      const agentScope = resolveAgentScope(opts);
+      params.push(agentScope.agentId);
+      clauses.push(agentScopeCondition(`$${params.length}`, agentScope, "ce_from.agent_id"));
+      clauses.push(agentScopeCondition(`$${params.length}`, agentScope, "ce_to.agent_id"));
+      for (const alias of ["ce_from.key_id", "ce_to.key_id"]) {
+        const keyClause = keyScopeClause(params, alias, {
+          keyId: opts.keyId ?? null, groupKeyIds: opts.groupKeyIds
+        });
+        if (keyClause) clauses.push(keyClause.trim().replace(/^AND\s+/, ""));
+      }
+      appendWorkspaceScope(params, clauses, opts, ["ce_from.workspace", "ce_to.workspace"]);
+    } else if (opts.keyId != null) {
+      params.push(opts.keyId);
+      clauses.push(`ce_from.key_id = $${params.length}`);
+      clauses.push(`ce_to.key_id = $${params.length}`);
     }
 
+    const extra = clauses.length > 0 ? `AND ${clauses.join(" AND ")}` : "";
     const { rows } = await pool.query(
-      `SELECT from_event_id, to_event_id, edge_type, confidence
-         FROM ${SCHEMA}.case_event_edges
-        WHERE from_event_id = ANY($1::uuid[])
-           OR to_event_id   = ANY($1::uuid[])`,
-      [eventIds]
+      `SELECT ee.from_event_id, ee.to_event_id, ee.edge_type, ee.confidence
+         FROM ${SCHEMA}.case_event_edges ee
+         JOIN ${SCHEMA}.case_events ce_from ON ce_from.event_id = ee.from_event_id
+         JOIN ${SCHEMA}.case_events ce_to   ON ce_to.event_id   = ee.to_event_id
+        WHERE (ee.from_event_id = ANY($1::uuid[]) OR ee.to_event_id = ANY($1::uuid[]))
+          ${extra}`,
+      params
     );
     return rows;
   }
@@ -296,20 +358,43 @@ export class CaseEventStore {
    * @param {number|null} [keyId=null] - API 키 격리 필터
    * @returns {Promise<Object[]>} { fragment_id, content, type, topic, keywords, kind, confidence }
    */
-  async getEvidenceByEvent(eventId, keyId = null) {
+  async getEvidenceByEvent(eventId, keyOrOpts = null) {
     const pool = getPrimaryPool();
     if (!pool) return [];
 
-    const params    = [eventId];
-    const keyClause = keyScopeScalar(params, "f.key_id", keyId).trimStart();
+    const opts = keyOrOpts && typeof keyOrOpts === "object"
+      ? keyOrOpts
+      : { keyId: keyOrOpts };
+    const params = [eventId];
+    const clauses = [];
+    if (opts.agentId !== undefined) {
+      const agentScope = resolveAgentScope(opts);
+      params.push(agentScope.agentId);
+      clauses.push(agentScopeCondition(`$${params.length}`, agentScope, "ce.agent_id"));
+      clauses.push(agentScopeCondition(`$${params.length}`, agentScope, "f.agent_id"));
+      for (const alias of ["ce.key_id", "f.key_id"]) {
+        const keyClause = keyScopeClause(params, alias, {
+          keyId: opts.keyId ?? null, groupKeyIds: opts.groupKeyIds
+        });
+        if (keyClause) clauses.push(keyClause.trim().replace(/^AND\s+/, ""));
+      }
+      appendWorkspaceScope(params, clauses, opts, ["ce.workspace", "f.workspace"]);
+    } else {
+      const eventKey = keyScopeScalar(params, "ce.key_id", opts.keyId ?? null);
+      const fragmentKey = keyScopeScalar(params, "f.key_id", opts.keyId ?? null);
+      if (eventKey) clauses.push(eventKey.trim().replace(/^AND\s+/, ""));
+      if (fragmentKey) clauses.push(fragmentKey.trim().replace(/^AND\s+/, ""));
+    }
+    const scopeClause = clauses.length > 0 ? `AND ${clauses.join(" AND ")}` : "";
 
     const { rows } = await pool.query(
       `SELECT f.id AS fragment_id, f.content, f.type, f.topic, f.keywords,
               fe.kind, fe.confidence
          FROM ${SCHEMA}.fragment_evidence fe
          JOIN ${SCHEMA}.fragments f ON f.id = fe.fragment_id
+         JOIN ${SCHEMA}.case_events ce ON ce.event_id = fe.event_id
         WHERE fe.event_id = $1
-          ${keyClause}
+          ${scopeClause}
         ORDER BY fe.confidence DESC`,
       params
     );
@@ -324,12 +409,29 @@ export class CaseEventStore {
    * @param {number|null} [keyId=null] - API 키 격리 필터
    * @returns {Promise<Object[]>} { event_id, case_id, event_type, summary, created_at, kind, confidence }
    */
-  async getEventsByFragment(fragmentId, keyId = null) {
+  async getEventsByFragment(fragmentId, keyOrOpts = null) {
     const pool = getPrimaryPool();
     if (!pool) return [];
 
-    const params    = [fragmentId];
-    const keyClause = keyScopeScalar(params, "ce.key_id", keyId).trimStart();
+    const opts = keyOrOpts && typeof keyOrOpts === "object"
+      ? keyOrOpts
+      : { keyId: keyOrOpts };
+    const params = [fragmentId];
+    const clauses = [];
+    if (opts.agentId !== undefined) {
+      const agentScope = resolveAgentScope(opts);
+      params.push(agentScope.agentId);
+      clauses.push(agentScopeCondition(`$${params.length}`, agentScope, "ce.agent_id"));
+      const keyClause = keyScopeClause(params, "ce.key_id", {
+        keyId: opts.keyId ?? null, groupKeyIds: opts.groupKeyIds
+      });
+      if (keyClause) clauses.push(keyClause.trim().replace(/^AND\s+/, ""));
+      appendWorkspaceScope(params, clauses, opts, ["ce.workspace"]);
+    } else {
+      const keyClause = keyScopeScalar(params, "ce.key_id", opts.keyId ?? null);
+      if (keyClause) clauses.push(keyClause.trim().replace(/^AND\s+/, ""));
+    }
+    const scopeClause = clauses.length > 0 ? `AND ${clauses.join(" AND ")}` : "";
 
     const { rows } = await pool.query(
       `SELECT ce.event_id, ce.case_id, ce.event_type, ce.summary, ce.created_at,
@@ -337,7 +439,7 @@ export class CaseEventStore {
          FROM ${SCHEMA}.fragment_evidence fe
          JOIN ${SCHEMA}.case_events ce ON ce.event_id = fe.event_id
         WHERE fe.fragment_id = $1
-          ${keyClause}
+          ${scopeClause}
         ORDER BY ce.created_at ASC`,
       params
     );

--- a/lib/memory/FragmentIndex.js
+++ b/lib/memory/FragmentIndex.js
@@ -95,8 +95,12 @@ export class FragmentIndex {
   /**
      * 파편을 역인덱스에 등록
      */
-  async index(fragment, sessionId, keyId = null) {
-    if (!redisClient || redisClient.status !== "ready") return;
+  async index(fragment, sessionId, keyId = null, opts = {}) {
+    if (!redisClient || redisClient.status === "stub") return;
+    if (redisClient.status !== "ready") {
+      if (opts.strict === true) throw new Error(`Redis index unavailable (${redisClient.status})`);
+      return;
+    }
 
     const ns       = keyNs(keyId);
     const pipeline = redisClient.pipeline();
@@ -128,16 +132,25 @@ export class FragmentIndex {
       pipeline.expire(`${SESSION_PREFIX}${sessionId}`, 86400);
     }
 
-    await pipeline.exec().catch(err =>
-      logWarn(`[FragmentIndex] index failed: ${err.message}`)
-    );
+    try {
+      const replies = await pipeline.exec();
+      const replyError = replies?.find?.(([err]) => err)?.[0];
+      if (replyError) throw replyError;
+    } catch (err) {
+      if (opts.strict === true) throw err;
+      logWarn(`[FragmentIndex] index failed: ${err.message}`);
+    }
   }
 
   /**
      * 파편을 역인덱스에서 제거
      */
-  async deindex(fragmentId, keywords, topic, type, keyId = null) {
-    if (!redisClient || redisClient.status !== "ready") return;
+  async deindex(fragmentId, keywords, topic, type, keyId = null, opts = {}) {
+    if (!redisClient || redisClient.status === "stub") return;
+    if (redisClient.status !== "ready") {
+      if (opts.strict === true) throw new Error(`Redis index unavailable (${redisClient.status})`);
+      return;
+    }
 
     const ns       = keyNs(keyId);
     const pipeline = redisClient.pipeline();
@@ -151,9 +164,14 @@ export class FragmentIndex {
     pipeline.zrem(`${RECENT_KEY}:${ns}`, fragmentId);
     pipeline.del(`${HOT_PREFIX}${ns}:${fragmentId}`);
 
-    await pipeline.exec().catch(err =>
-      logWarn(`[FragmentIndex] deindex failed: ${err.message}`)
-    );
+    try {
+      const replies = await pipeline.exec();
+      const replyError = replies?.find?.(([err]) => err)?.[0];
+      if (replyError) throw replyError;
+    } catch (err) {
+      if (opts.strict === true) throw err;
+      logWarn(`[FragmentIndex] deindex failed: ${err.message}`);
+    }
   }
 
   /**
@@ -277,16 +295,22 @@ export class FragmentIndex {
      */
   async addToWorkingMemory(sessionId, fragment) {
     if (!redisClient || redisClient.status !== "ready" || !sessionId) return;
-
     const key = `${WM_PREFIX}${sessionId}`;
 
     try {
+      const hasKey = Object.prototype.hasOwnProperty.call(fragment, "key_id");
+      const hasWorkspace = Object.prototype.hasOwnProperty.call(fragment, "workspace");
+      if (typeof fragment.agent_id !== "string" || !hasKey || !hasWorkspace) {
+        throw new Error("Working Memory fragment requires resolved agent/key/workspace metadata");
+      }
       const entry = JSON.stringify({
         id              : fragment.id,
         content         : fragment.content,
         type            : fragment.type,
         topic           : fragment.topic,
+        agent_id        : fragment.agent_id,
         workspace       : fragment.workspace ?? null,
+        key_id          : fragment.key_id,
         importance      : fragment.importance || 0.5,
         estimated_tokens: fragment.estimated_tokens || Math.ceil((fragment.content || "").length / 4),
         added_at        : Date.now()

--- a/lib/memory/MemoryManager.js
+++ b/lib/memory/MemoryManager.js
@@ -242,6 +242,17 @@ export class MemoryManager {
   async remember(params)           { return this.rememberer.remember(params); }
   async batchRemember(params, onProgress = null) { return this.rememberer.batchRemember(params, onProgress); }
   async amend(params)              { return this.rememberer.amend(params); }
+  async normalizeAnchorAgentToDefault(id, currentAgentId) {
+    return this.rememberer.normalizeAnchorAgentToDefault(id, currentAgentId);
+  }
+
+  async validateFragmentAgentNormalization(id, currentAgentId, opts) {
+    return this.rememberer.validateFragmentAgentNormalization(id, currentAgentId, opts);
+  }
+
+  async normalizeFragmentAgentToDefault(id, currentAgentId, opts) {
+    return this.rememberer.normalizeFragmentAgentToDefault(id, currentAgentId, opts);
+  }
   async forget(params)             { return this.rememberer.forget(params); }
 
   async recall(params)             { return this.recaller.recall(params); }

--- a/lib/memory/admin/AgentScopeBackfill.js
+++ b/lib/memory/admin/AgentScopeBackfill.js
@@ -1,0 +1,216 @@
+import { getPrimaryPool } from "../../tools/db.js";
+import { SCHEMA } from "../schema.js";
+
+const REQUIRED_COLUMNS = [
+  ["fragment_versions", "agent_id"],
+  ["fragment_versions", "workspace"],
+  ["case_events", "agent_id"],
+  ["case_events", "workspace"]
+];
+
+/** migration-047의 nullable snapshot 컬럼이 모두 적용됐는지 확인한다. */
+export async function hasAgentScopeSnapshotSchema(pool = getPrimaryPool()) {
+  if (!pool) return false;
+  const { rows } = await pool.query(
+    `SELECT table_name, column_name
+       FROM information_schema.columns
+      WHERE table_schema = $1
+        AND (table_name, column_name) IN (
+          ('fragment_versions', 'agent_id'),
+          ('fragment_versions', 'workspace'),
+          ('case_events', 'agent_id'),
+          ('case_events', 'workspace')
+        )`,
+    [SCHEMA]
+  );
+  const found = new Set(rows.map(row => `${row.table_name}.${row.column_name}`));
+  return REQUIRED_COLUMNS.every(([table, column]) => found.has(`${table}.${column}`));
+}
+
+/** 본문과 식별자를 노출하지 않는 legacy snapshot 사전 영향 집계. */
+export async function getAgentScopeBackfillStatus(pool = getPrimaryPool()) {
+  if (!await hasAgentScopeSnapshotSchema(pool)) {
+    return { migrationReady: false };
+  }
+
+  const versions = await pool.query(
+    `SELECT COUNT(*) FILTER (WHERE fv.agent_id IS NULL)::int AS pending,
+            COUNT(*) FILTER (WHERE fv.agent_id IS NULL AND f.id IS NOT NULL)::int AS backfillable
+       FROM ${SCHEMA}.fragment_versions fv
+       LEFT JOIN ${SCHEMA}.fragments f ON f.id = fv.fragment_id`
+  );
+  const events = await pool.query(
+    `SELECT COUNT(*) FILTER (WHERE ce.agent_id IS NULL)::int AS pending,
+            COUNT(*) FILTER (
+              WHERE ce.agent_id IS NULL AND ce.source_fragment_id IS NOT NULL AND f.id IS NOT NULL
+            )::int AS backfillable,
+            COUNT(*) FILTER (
+              WHERE ce.agent_id IS NULL AND ce.source_fragment_id IS NULL
+            )::int AS "sourceMissing",
+            COUNT(*) FILTER (
+              WHERE ce.agent_id IS NULL AND ce.source_fragment_id IS NOT NULL AND f.id IS NULL
+            )::int AS "sourceDeleted"
+       FROM ${SCHEMA}.case_events ce
+       LEFT JOIN ${SCHEMA}.fragments f ON f.id = ce.source_fragment_id`
+  );
+
+  return {
+    migrationReady: true,
+    fragmentVersions: versions.rows[0],
+    caseEvents: events.rows[0]
+  };
+}
+
+/** 공유 범위로 바꾸려는 파편의 version/event snapshot이 모두 복구됐는지 확인한다. */
+export async function getPendingScopeSnapshotCounts(fragmentIds, pool = getPrimaryPool()) {
+  if (!Array.isArray(fragmentIds) || fragmentIds.length === 0) {
+    return { fragmentVersions: 0, caseEvents: 0, total: 0 };
+  }
+  if (!await hasAgentScopeSnapshotSchema(pool)) {
+    throw new Error("migration-047 must be applied before agent scope normalization");
+  }
+  const { rows } = await pool.query(
+    `SELECT
+       (SELECT COUNT(*)::int
+          FROM ${SCHEMA}.fragment_versions
+         WHERE fragment_id = ANY($1::text[])
+           AND agent_id IS NULL) AS "fragmentVersions",
+       (SELECT COUNT(*)::int
+          FROM ${SCHEMA}.case_events
+         WHERE source_fragment_id = ANY($1::text[])
+           AND agent_id IS NULL) AS "caseEvents"`,
+    [fragmentIds]
+  );
+  const fragmentVersions = rows[0]?.fragmentVersions ?? 0;
+  const caseEvents = rows[0]?.caseEvents ?? 0;
+  return { fragmentVersions, caseEvents, total: fragmentVersions + caseEvents };
+}
+
+export function assertBackfillComplete(status) {
+  const pending = (status?.fragmentVersions?.backfillable ?? 0)
+    + (status?.caseEvents?.backfillable ?? 0);
+  const sourceMissing = status?.caseEvents?.sourceMissing ?? 0;
+  const sourceDeleted = status?.caseEvents?.sourceDeleted ?? 0;
+  const unresolved = Math.max(pending,
+    (status?.fragmentVersions?.pending ?? 0) + (status?.caseEvents?.pending ?? 0));
+  if (status?.migrationReady === false) {
+    throw new Error("agent scope snapshot schema is not ready");
+  }
+  if (unresolved > 0 || sourceMissing > 0 || sourceDeleted > 0) {
+    const error = new Error(
+      `snapshot backfill left ${pending} backfillable row(s), ` +
+      `sourceMissing=${sourceMissing}, sourceDeleted=${sourceDeleted}; ` +
+      "rerun for locked/concurrent rows; source-less snapshots require operator review and remain fail-closed"
+    );
+    error.code = "SNAPSHOT_BACKFILL_INCOMPLETE";
+    error.status = status;
+    throw error;
+  }
+}
+
+/** Migration only reports counts; snapshot rewriting remains an explicit operator action. */
+export async function warnPendingAgentScopeSnapshots(pool, warn = console.warn) {
+  const status = await getAgentScopeBackfillStatus(pool);
+  if (!status.migrationReady) return status;
+  if ((status.fragmentVersions?.pending ?? 0) + (status.caseEvents?.pending ?? 0) > 0) {
+    warn("Agent scope snapshots remain pending: " + JSON.stringify(status) +
+      "; inspect with memento-mcp anchor-scope --backfill-snapshots before opting into peer reads.");
+  }
+  return status;
+}
+
+async function backfillFragmentVersionBatch(pool, batchSize) {
+  const result = await pool.query(
+    `WITH batch AS (
+       SELECT fv.id, f.agent_id, f.workspace
+         FROM ${SCHEMA}.fragment_versions fv
+         JOIN ${SCHEMA}.fragments f ON f.id = fv.fragment_id
+        WHERE fv.agent_id IS NULL
+        ORDER BY fv.id
+        LIMIT $1
+        FOR UPDATE OF fv SKIP LOCKED
+     )
+     UPDATE ${SCHEMA}.fragment_versions fv
+        SET agent_id = batch.agent_id,
+            workspace = batch.workspace
+       FROM batch
+      WHERE fv.id = batch.id`,
+    [batchSize]
+  );
+  return result.rowCount ?? 0;
+}
+
+async function backfillCaseEventBatch(pool, batchSize) {
+  const result = await pool.query(
+    `WITH batch AS (
+       SELECT ce.event_id, f.agent_id, f.workspace
+         FROM ${SCHEMA}.case_events ce
+         JOIN ${SCHEMA}.fragments f ON f.id = ce.source_fragment_id
+        WHERE ce.agent_id IS NULL
+        ORDER BY ce.event_id
+        LIMIT $1
+        FOR UPDATE OF ce SKIP LOCKED
+     )
+     UPDATE ${SCHEMA}.case_events ce
+        SET agent_id = batch.agent_id,
+            workspace = batch.workspace
+       FROM batch
+      WHERE ce.event_id = batch.event_id`,
+    [batchSize]
+  );
+  return result.rowCount ?? 0;
+}
+
+/** 신뢰 가능한 source fragment가 남은 snapshot만 짧은 트랜잭션으로 backfill한다. */
+export async function backfillAgentScopeSnapshots(
+  { batchSize = 500, maxBatches = 1000 } = {}, pool = getPrimaryPool()
+) {
+  if (!Number.isInteger(batchSize) || batchSize < 1 || batchSize > 10_000) {
+    throw new Error("batchSize must be an integer between 1 and 10000");
+  }
+  if (!Number.isSafeInteger(maxBatches) || maxBatches < 1) {
+    throw new Error("maxBatches must be a positive safe integer");
+  }
+  if (!await hasAgentScopeSnapshotSchema(pool)) {
+    throw new Error("migration-047 must be applied before snapshot backfill");
+  }
+
+  let fragmentVersions = 0;
+  let caseEvents = 0;
+  let batches = 0;
+  function reserveBatch() {
+    if (batches >= maxBatches) {
+      const error = new Error(
+        `snapshot backfill reached the ${maxBatches}-batch limit; ` +
+        `committed progress: versions=${fragmentVersions}, events=${caseEvents}; ` +
+        "rerun to resume remaining rows after concurrent writers finish"
+      );
+      error.code = "SNAPSHOT_BACKFILL_LIMIT";
+      error.progress = { fragmentVersions, caseEvents, batches };
+      throw error;
+    }
+    batches++;
+  }
+  for (;;) {
+    reserveBatch();
+    const updated = await backfillFragmentVersionBatch(pool, batchSize);
+    fragmentVersions += updated;
+    if (updated === 0) break;
+  }
+  for (;;) {
+    reserveBatch();
+    const updated = await backfillCaseEventBatch(pool, batchSize);
+    caseEvents += updated;
+    if (updated === 0) break;
+  }
+  // SKIP LOCKED can return zero while rows remain locked. Verify independently
+  // so direct callers cannot mistake exhausted available batches for completion.
+  const status = await getAgentScopeBackfillStatus(pool);
+  try {
+    assertBackfillComplete(status);
+  } catch (error) {
+    error.progress = { fragmentVersions, caseEvents, batches };
+    throw error;
+  }
+  return { fragmentVersions, caseEvents };
+}

--- a/lib/memory/admin/AnchorScopeInventory.js
+++ b/lib/memory/admin/AnchorScopeInventory.js
@@ -1,0 +1,18 @@
+/** content를 노출하지 않고 anchor inventory 분류만 수행한다. */
+export function classifyAnchors(rows, classifications) {
+  for (const id of classifications.shared) {
+    if (classifications.private.has(id)) {
+      throw new Error(`anchor classification conflict: ${id}`);
+    }
+  }
+  return rows.map(row => ({
+    id        : row.id,
+    agentId   : row.agent_id,
+    workspace : row.workspace ?? null,
+    keyId     : row.key_id ?? null,
+    isAnchor  : row.is_anchor === true,
+    category  : classifications.shared.has(row.id)
+      ? "shared"
+      : (classifications.private.has(row.id) ? "private" : "unconfirmed")
+  }));
+}

--- a/lib/memory/link/LinkStore.js
+++ b/lib/memory/link/LinkStore.js
@@ -12,6 +12,7 @@ import { keyScopeClause, keyScopeGroup, keyScopeNullable }       from "../keySco
 import { SCHEMA } from "../schema.js";
 import { normalizeIsAnchor } from "../read/SearchScope.js";
 import { workspaceCondition } from "../read/WorkspaceScope.js";
+import { agentScopeCondition, resolveAgentScope } from "../read/AgentScope.js";
 
 /**
  * 관계 종류 우선순위. 값이 클수록 구체적인 관계이며 덮어쓰기 대상이 아니다.
@@ -447,20 +448,27 @@ export class LinkStore {
    * @param {string} agentId
    * @returns {Promise<object[]>}
    */
-  async getRCAChain(startId, agentId = "default", keyId = null, groupKeyIds = []) {
-    const params = [startId];
+  async getRCAChain(startId, agentId = "default", keyId = null, groupKeyIds = [], opts = {}) {
+    const agentScope = resolveAgentScope({ ...opts, agentId });
+    const params = [startId, agentScope.agentId];
     const scope  = { keyId, groupKeyIds };
     const seedKeyFilter = keyScopeClause(params, "f.key_id",  scope);
     const keyFilter     = keyScopeClause(params, "f2.key_id", scope);
+    const seedWorkspaceClause = workspaceCondition(params, opts, "f.workspace");
+    const seedWorkspaceFilter = seedWorkspaceClause ? `AND ${seedWorkspaceClause}` : "";
+    const targetWorkspaceClause = workspaceCondition(params, opts, "f2.workspace");
+    const targetWorkspaceFilter = targetWorkspaceClause ? `AND ${targetWorkspaceClause}` : "";
 
-    const result = await queryWithAgentVector(agentId,
+    const result = await queryWithAgentVector(agentScope.agentId,
       `WITH rca AS (
          SELECT f.id, f.content, f.type, f.importance, f.topic,
                 NULL::text AS relation_type, 0 AS depth
          FROM ${SCHEMA}.fragments f
          WHERE f.id = $1
            AND f.valid_to IS NULL
+           AND ${agentScopeCondition("$2", agentScope, "f.agent_id")}
            ${seedKeyFilter}
+           ${seedWorkspaceFilter}
 
          UNION ALL
 
@@ -471,7 +479,9 @@ export class LinkStore {
          WHERE l.from_id = $1
            AND l.relation_type IN ('caused_by', 'resolved_by')
            AND f2.valid_to IS NULL
+           AND ${agentScopeCondition("$2", agentScope, "f2.agent_id")}
            ${keyFilter}
+           ${targetWorkspaceFilter}
        )
        SELECT * FROM rca ORDER BY depth ASC, importance DESC`,
       params

--- a/lib/memory/memory-schema.sql
+++ b/lib/memory/memory-schema.sql
@@ -130,7 +130,9 @@ CREATE TABLE IF NOT EXISTS agent_memory.fragment_versions (
     type         TEXT,
     importance   REAL,
     amended_at   TIMESTAMPTZ DEFAULT NOW(),
-    amended_by   TEXT -- agent_id
+    amended_by   TEXT, -- 수정 주체 agent_id
+    agent_id     TEXT, -- 수정 전 소유 agent_id; legacy row backfill 전에는 NULL 가능
+    workspace    TEXT  -- 수정 전 workspace
 );
 
 CREATE INDEX IF NOT EXISTS idx_ver_frag ON agent_memory.fragment_versions(fragment_id);

--- a/lib/memory/migrations/migration-047-agent-scope-audit.sql
+++ b/lib/memory/migrations/migration-047-agent-scope-audit.sql
@@ -1,0 +1,31 @@
+-- effective agent 검색 범위 및 anchor agent 변경 이력 보존
+
+ALTER TABLE agent_memory.search_events
+  ADD COLUMN IF NOT EXISTS effective_agent_scope TEXT,
+  ADD COLUMN IF NOT EXISTS include_peer_agents  BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE agent_memory.fragment_versions
+  ADD COLUMN IF NOT EXISTS agent_id  TEXT,
+  ADD COLUMN IF NOT EXISTS workspace TEXT;
+
+ALTER TABLE agent_memory.case_events
+  ADD COLUMN IF NOT EXISTS agent_id  TEXT,
+  ADD COLUMN IF NOT EXISTS workspace TEXT;
+
+-- 기존 행 backfill은 이 migration의 트랜잭션에서 수행하지 않는다. 대형 테이블의
+-- 전 행 재작성과 코드 롤링 배포를 분리하기 위해 `anchor-scope --backfill-snapshots`가
+-- 짧은 배치 단위로 처리한다. nullable 상태는 구버전 writer와 호환되며, 읽기
+-- 경로는 NULL snapshot을 fail-closed로 제외한다.
+
+COMMENT ON COLUMN agent_memory.search_events.effective_agent_scope
+  IS '검색에 적용된 비식별 agent 범위: default-only, specific+default, all-agents';
+COMMENT ON COLUMN agent_memory.search_events.include_peer_agents
+  IS 'master가 명시적으로 peer-agent 전체 조회를 요청했는지 여부';
+COMMENT ON COLUMN agent_memory.fragment_versions.agent_id
+  IS 'amend 직전 fragment agent_id. 승인된 공유 정규화는 같은 트랜잭션에서 version agent도 default로 이관한다. NULL은 미복구 snapshot.';
+COMMENT ON COLUMN agent_memory.fragment_versions.workspace
+  IS 'amend 직전 fragment workspace. history hydration 범위 검증용.';
+COMMENT ON COLUMN agent_memory.case_events.agent_id
+  IS 'event 생성 시 source fragment agent scope snapshot. NULL은 귀속 불명으로 peer를 포함한 조회에서 제외한다.';
+COMMENT ON COLUMN agent_memory.case_events.workspace
+  IS 'event 생성 시 source fragment workspace snapshot.';

--- a/lib/memory/processors/EpisodeContinuityService.js
+++ b/lib/memory/processors/EpisodeContinuityService.js
@@ -12,6 +12,7 @@
 import { getPrimaryPool } from "../../tools/db.js";
 import { logWarn }        from "../../logger.js";
 import { SCHEMA } from "../schema.js";
+import { keyScopeNullable } from "../keyScope.js";
 
 const CACHE_TTL_MS      = parseInt(process.env.EPISODE_CONTINUITY_CACHE_TTL_MS || "5000", 10);
 const MAX_TRACKED_SCOPES = 1000;
@@ -61,21 +62,27 @@ export const _lastEventCacheForTest  = () => lastEventCache;
  * @returns {Promise<string|null>}
  */
 async function findLastMilestoneEventId(pool, agentId, keyId, scopeType, scopeValue) {
+  const params = [agentId];
+  const keyClause = keyScopeNullable(params, "ce.key_id", keyId).trimStart();
+  params.push(scopeValue);
   const scopeCondition = scopeType === "workspace"
-    ? "f.workspace = $3"
-    : "f.workspace IS NULL AND f.topic = $3";
+    ? "ce.workspace = $3"
+    : "ce.workspace IS NULL AND f.topic = $3";
+  const topicJoin = scopeType === "topic"
+    ? `JOIN ${SCHEMA}.fragments f ON f.id = ce.source_fragment_id`
+    : "";
 
   const r = await pool.query(`
     SELECT ce.event_id
     FROM ${SCHEMA}.case_events ce
-    JOIN ${SCHEMA}.fragments f ON f.id = ce.source_fragment_id
+    ${topicJoin}
     WHERE ce.event_type = 'milestone_reached'
-      AND f.agent_id = $1
-      AND ce.key_id IS NOT DISTINCT FROM $2
+      AND ce.agent_id = $1
+      ${keyClause}
       AND ${scopeCondition}
     ORDER BY ce.created_at DESC
     LIMIT 1
-  `, [agentId, keyId ?? null, scopeValue]);
+  `, params);
 
   return r.rows[0]?.event_id ?? null;
 }
@@ -103,12 +110,20 @@ export async function linkEpisodeMilestone(episodeFragmentId, agentId, keyId, se
 
   try {
     /** fragment summary + 체인 스코프 결정용 workspace/topic 조회 */
+    const fragmentParams = [episodeFragmentId, agentId];
+    const fragmentKeyClause = keyScopeNullable(
+      fragmentParams, "key_id", keyId
+    ).trimStart();
     const fragR = await pool.query(
-      `SELECT LEFT(content, 200) AS summary, workspace, topic
-       FROM ${SCHEMA}.fragments WHERE id = $1`,
-      [episodeFragmentId]
+      `SELECT LEFT(content, 200) AS summary, workspace, topic, agent_id, key_id
+       FROM ${SCHEMA}.fragments
+       WHERE id = $1
+         AND agent_id = $2
+         ${fragmentKeyClause}`,
+      fragmentParams
     );
     const fragRow    = fragR.rows[0];
+    if (!fragRow) return;
     const summary    = fragRow?.summary ?? "";
     const workspace  = fragRow?.workspace ?? null;
     const topic      = fragRow?.topic ?? null;
@@ -116,8 +131,9 @@ export async function linkEpisodeMilestone(episodeFragmentId, agentId, keyId, se
     /** milestone_reached 이벤트 삽입 (멱등) */
     const evR = await pool.query(`
       INSERT INTO ${SCHEMA}.case_events
-        (event_type, summary, source_fragment_id, case_id, session_id, idempotency_key, key_id)
-      VALUES ('milestone_reached', $1, $2, $3, $4, $5, $6)
+        (event_type, summary, source_fragment_id, case_id, session_id, idempotency_key,
+         key_id, agent_id, workspace)
+      VALUES ('milestone_reached', $1, $2, $3, $4, $5, $6, $7, $8)
       ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING
       RETURNING event_id
     `, [
@@ -126,7 +142,9 @@ export async function linkEpisodeMilestone(episodeFragmentId, agentId, keyId, se
       sessionId ?? "unknown",
       sessionId ?? null,
       idempotencyKey,
-      keyId ?? null
+      keyId ?? null,
+      fragRow.agent_id,
+      workspace
     ]);
 
     const eventId = evR.rows[0]?.event_id;

--- a/lib/memory/processors/MemoryRecaller.js
+++ b/lib/memory/processors/MemoryRecaller.js
@@ -149,7 +149,7 @@ export class MemoryRecaller {
       ...(params.resolutionStatus  ? { resolutionStatus: params.resolutionStatus } : {}),
       ...(params.phase             ? { phase: params.phase } : {}),
       ...(params.affect            ? { affect: params.affect } : {}),
-      ...(params.includePeerAgents === true ? { includePeerAgents: true } : {}),
+      ...(params.includePeerAgents === true ? { includePeerAgents: true, _isMaster: params._isMaster === true } : {}),
       ...(params.includeKeyName === true ? { includeKeyName: true } : {})
       /** H2 Sparse Fieldsets: 필드 선택은 응답 프로젝션(buildRecallResponse)에서 최종 적용한다.
        *  파생 키(confidence, age_days) 산출에 원시 컬럼이 필요하므로 검색 계층에서는 자르지 않는다. */
@@ -169,6 +169,7 @@ export class MemoryRecaller {
         {
           workspace,
           allWorkspaces,
+          ...(params._isMaster === true ? { _isMaster: true } : {}),
           includePeerAgents: params.includePeerAgents === true,
           ...(params.includeSuperseded === true ? { includeSuperseded: true } : {}),
           ...(params.isAnchor !== undefined ? { isAnchor: params.isAnchor } : {})
@@ -178,8 +179,9 @@ export class MemoryRecaller {
         agentId,
         workspace,
         allWorkspaces,
+        ...(params._isMaster === true ? { _isMaster: true } : {}),
         includePeerAgents: params.includePeerAgents === true,
-        ...(params.isAnchor !== undefined ? { isAnchor: params.isAnchor } : {})
+        ...(params.isAnchor !== undefined ? { isAnchor: params.isAnchor } : {}),
       });
       const scopedLinkedFrags = linkedScope.isNoop()
         ? linkedFrags
@@ -283,7 +285,12 @@ export class MemoryRecaller {
     if (result.count === 0 && params.topic) {
       result._topicCandidates = await suggestTopics(
         this.store,
-        { keyId, groupKeyIds, workspace, allWorkspaces },
+        {
+          keyId, groupKeyIds, agentId, workspace,
+          allWorkspaces,
+          ...(params._isMaster === true ? { _isMaster: true } : {}),
+          includePeerAgents: params.includePeerAgents === true
+        },
         params.topic
       );
     }
@@ -298,7 +305,10 @@ export class MemoryRecaller {
         allWorkspaces,
         maxCases: params.maxCases || 5,
         ...(params.includeSuperseded === true ? { includeSuperseded: true } : {}),
-        ...(params.isAnchor !== undefined ? { isAnchor: params.isAnchor } : {})
+        ...(params.isAnchor !== undefined ? { isAnchor: params.isAnchor } : {}),
+        agentId,
+        ...(params._isMaster === true ? { _isMaster: true } : {}),
+        includePeerAgents: params.includePeerAgents === true
       });
 
       return {
@@ -435,6 +445,7 @@ export class MemoryRecaller {
    * @returns {Object} { current, versions, superseded_by_chain }
    */
   async fragmentHistory(params) {
+    const { workspace, allWorkspaces } = resolveWorkspaceScope(params);
     if (!params.id) {
       return { error: "id is required" };
     }
@@ -443,7 +454,12 @@ export class MemoryRecaller {
     /** getHistory 내부 getById에 keyId 전달 — SQL 레벨 필터로 권한 없으면 current=null */
     const result = await this.store.getHistory(
       params.id, agentId, keyId, groupKeyIds,
-      { includePeerAgents: params.includePeerAgents === true }
+      {
+        ...(params._isMaster === true ? { _isMaster: true } : {}),
+        includePeerAgents: params.includePeerAgents === true,
+        workspace,
+        allWorkspaces
+      }
     );
     if (!result.current) return { error: "Fragment not found or no permission" };
 
@@ -460,19 +476,30 @@ export class MemoryRecaller {
    * @returns {Object} { startId, nodes, edges, count }
    */
   async graphExplore(params) {
+    const { workspace, allWorkspaces } = resolveWorkspaceScope(params);
     if (!params.startId) {
       return { error: "startId is required" };
     }
 
     const { agentId, keyId, groupKeyIds } = extractRequestCtx(params, { groupKeyIdsFallback: 'empty' });
+    const scopeOpts = {
+      workspace,
+      allWorkspaces,
+      ...(params._isMaster === true ? { _isMaster: true } : {}),
+      includePeerAgents: params.includePeerAgents === true
+    };
 
     /** 시작 파편 소유권 확인 — SQL 레벨 필터로 권한 없으면 null 반환 */
-    const startFrag = await this.store.getById(params.startId, agentId, keyId, groupKeyIds);
+    const startFrag = await this.store.getById(
+      params.startId, agentId, keyId, groupKeyIds, scopeOpts
+    );
     if (!startFrag) {
       return { error: "Fragment not found or no permission" };
     }
 
-    const nodes = await this.store.getRCAChain(params.startId, agentId, keyId, groupKeyIds);
+    const nodes = await this.store.getRCAChain(
+      params.startId, agentId, keyId, groupKeyIds, scopeOpts
+    );
 
     const edges = nodes
       .filter(n => n.relation_type)

--- a/lib/memory/processors/MemoryReflector.js
+++ b/lib/memory/processors/MemoryReflector.js
@@ -66,7 +66,11 @@ export class MemoryReflector {
       limit       : params.limit        ?? 100,
       keyId       : params.keyId        ?? params._keyId        ?? null,
       groupKeyIds : params.groupKeyIds  ?? params._groupKeyIds  ?? [],
-      workspace   : params.workspace    ?? params._defaultWorkspace ?? null
+      workspace   : params.workspace    ?? params._defaultWorkspace ?? null,
+      allWorkspaces: params.allWorkspaces === true,
+      _isMaster   : params._isMaster === true,
+      agentId     : params.agentId      ?? "default",
+      includePeerAgents: params.includePeerAgents === true
     });
   }
 

--- a/lib/memory/processors/MemoryRememberer.js
+++ b/lib/memory/processors/MemoryRememberer.js
@@ -968,6 +968,122 @@ export class MemoryRememberer {
   }
 
   /**
+   * 승인 inventory CLI 전용 사전검증.
+   *
+   * inventory가 반환한 workspace를 다시 바인딩해야 global-only 기본값 아래에서도
+   * named-workspace 파편을 안전하게 찾을 수 있다. 실행 전에 승인 목록 전체를 이
+   * 메서드로 확인하면 뒤쪽 항목의 잘못된 scope 때문에 앞쪽 항목만 먼저 바뀌는
+   * 예측 가능한 부분 적용도 막을 수 있다.
+   */
+  async validateFragmentAgentNormalization(
+    id,
+    currentAgentId,
+    { anchorsOnly = true, workspace = null, allWorkspaces = false } = {}
+  ) {
+    const existing = await this.store.getById(id, currentAgentId, null, [], {
+      includePeerAgents: false,
+      workspace,
+      allWorkspaces
+    });
+    const expectedWorkspace = workspace ?? null;
+    const wrongWorkspace = allWorkspaces !== true
+      && (existing?.workspace ?? null) !== expectedWorkspace;
+    if (
+      !existing
+      || wrongWorkspace
+      || (anchorsOnly && existing.is_anchor !== true)
+      || existing.agent_id !== currentAgentId
+    ) {
+      return { valid: false, error: "Approved fragment not found in the expected agent scope" };
+    }
+    if (currentAgentId === "default") {
+      return { valid: false, error: "Fragment is already shared" };
+    }
+    return { valid: true, fragment: existing };
+  }
+
+  /** 승인 inventory CLI 전용: public amend schema를 우회하지 않는 내부 정규화 경로. */
+  async normalizeFragmentAgentToDefault(
+    id,
+    currentAgentId,
+    { anchorsOnly = true, workspace = null, allWorkspaces = false } = {}
+  ) {
+    const validation = await this.validateFragmentAgentNormalization(
+      id, currentAgentId, { anchorsOnly, workspace, allWorkspaces }
+    );
+    if (!validation.valid) {
+      return { updated: false, error: validation.error };
+    }
+    const existing = validation.fragment;
+
+    try {
+      await this.index.deindex(
+        existing.id, existing.keywords, existing.topic, existing.type,
+        existing.key_id ?? null, { strict: true }
+      );
+    } catch (err) {
+      return {
+        updated: false,
+        error: `Agent scope cache consistency failed: ${err.message}`
+      };
+    }
+
+    const restorePrivateIndex = async () => {
+      await this.index.index(
+        existing, null, existing.key_id ?? null, { strict: true }
+      );
+    };
+
+    let result;
+    try {
+      result = await this.store.update(
+        id, { agent_id: "default" }, currentAgentId, null, existing,
+        { amendedBy: "system:anchor-scope", normalizeVersionAgentToDefault: true }
+      );
+    } catch (err) {
+      try {
+        await restorePrivateIndex();
+      } catch (restoreErr) {
+        throw new Error(
+          "Agent scope database update and private cache restore both failed",
+          { cause: restoreErr }
+        );
+      }
+      throw err;
+    }
+    if (!result || result.merged) {
+      try {
+        await restorePrivateIndex();
+      } catch (restoreErr) {
+        throw new Error(
+          "Agent scope database update did not complete and private cache restore failed",
+          { cause: restoreErr }
+        );
+      }
+      return { updated: false, error: "Agent scope normalization failed" };
+    }
+
+    try {
+      await this.index.index(result, null, existing.key_id ?? null, { strict: true });
+    } catch (err) {
+      return {
+        updated: true,
+        databaseUpdated: true,
+        cacheConsistent: false,
+        cacheWarning: `Agent scope cache consistency failed: ${err.message}`,
+        fragment: result
+      };
+    }
+    return { updated: true, fragment: result };
+  }
+
+  normalizeAnchorAgentToDefault(id, currentAgentId, opts = {}) {
+    return this.normalizeFragmentAgentToDefault(
+      id, currentAgentId, { ...opts, anchorsOnly: true }
+    );
+  }
+
+  /**
    * forget - 파편 망각
    *
    * @param {Object} params

--- a/lib/memory/processors/MemoryRememberer.js
+++ b/lib/memory/processors/MemoryRememberer.js
@@ -128,7 +128,9 @@ export class MemoryRememberer {
     const workspace                       = params.workspace ?? params._defaultWorkspace ?? null;
     const source                          = params.source ?? (sessionId ? `session:${sessionId.slice(0, 8)}` : null);
 
-    const sessionResult = await this._handleSessionScope(params, scope, sessionId, workspace);
+    const sessionResult = await this._handleSessionScope(params, scope, sessionId, {
+      agentId, keyId, workspace
+    });
     if (sessionResult) return sessionResult;
 
     const idempotentResult = await this._checkIdempotency(params, keyId);
@@ -181,15 +183,19 @@ export class MemoryRememberer {
    * @param {string|null} sessionId
    * @returns {Promise<Object|null>}
    */
-  async _handleSessionScope(params, scope, sessionId, workspace = null) {
+  async _handleSessionScope(params, scope, sessionId, { agentId, keyId, workspace }) {
     if (scope !== "session" || !sessionId) return null;
 
     const fragment = this.factory.create({
       ...params,
       workspace,
+      agentId,
       contextSummary: params.contextSummary || null,
       sessionId
     });
+    fragment.agent_id = agentId;
+    fragment.key_id   = keyId;
+    fragment.workspace = workspace;
     await this.index.addToWorkingMemory(sessionId, fragment);
 
     return {
@@ -301,7 +307,15 @@ export class MemoryRememberer {
       return params;
     }
 
-    const existingCaseId = await this.store.findCaseIdBySessionTopic(sessionId, params.topic, keyId, groupKeyIds);
+    const caseScope = {
+      agentId: params.agentId || "default",
+      includePeerAgents: false,
+      workspace: params.workspace ?? params._defaultWorkspace ?? null,
+      allWorkspaces: false
+    };
+    const existingCaseId = await this.store.findCaseIdBySessionTopic(
+      sessionId, params.topic, keyId, groupKeyIds, caseScope
+    );
     if (existingCaseId) {
       return { ...params, caseId: existingCaseId };
     }
@@ -310,10 +324,14 @@ export class MemoryRememberer {
       return { ...params, caseId: crypto.randomUUID() };
     }
 
-    const errorIds = await this.store.findErrorFragmentsBySessionTopic(sessionId, params.topic, keyId, groupKeyIds);
+    const errorIds = await this.store.findErrorFragmentsBySessionTopic(
+      sessionId, params.topic, keyId, groupKeyIds, caseScope
+    );
     if (errorIds.length > 0) {
       const newCaseId = crypto.randomUUID();
-      Promise.all(errorIds.map(id => this.store.updateCaseId(id, newCaseId, keyId)))
+      Promise.all(errorIds.map(id => this.store.updateCaseId(
+        id, newCaseId, keyId, { ...caseScope, groupKeyIds }
+      )))
         .catch(err => logWarn(`[MemoryRememberer] auto-case-id backfill failed: ${err.message}`));
       return { ...params, caseId: newCaseId };
     }
@@ -701,6 +719,10 @@ export class MemoryRememberer {
     const eventType = MemoryRememberer.FRAG_TO_EVENT[fragment.type];
     if (!eventType) return;
 
+    // Callers run after the insert transaction commits. A persisted fragment's
+    // source key may differ from the caller key (for example, a shared result).
+    const sourceKeyId = Object.hasOwn(fragment, "key_id") ? fragment.key_id : keyId;
+
     const { event_id } = await this.caseEventStore.append({
       case_id           : fragment.case_id,
       session_id        : fragment.session_id ?? null,
@@ -708,14 +730,21 @@ export class MemoryRememberer {
       summary           : (fragment.content || "").slice(0, 200),
       entity_keys       : fragment.keywords || [],
       source_fragment_id: fragment.id,
-      key_id            : keyId
+      key_id            : sourceKeyId ?? null
     });
 
     /** fragment_evidence: 이 파편이 이벤트의 근거 */
     await this.caseEventStore.addEvidence(fragment.id, event_id, "produced_by").catch(() => {});
 
     /** preceded_by: 동일 case_id의 직전 이벤트와 연결 */
-    const prevEvents = await this.caseEventStore.getByCase(fragment.case_id, { limit: 2, keyId });
+    const eventScope = {
+      keyId: sourceKeyId ?? null,
+      agentId: fragment.agent_id ?? "default",
+      workspace: fragment.workspace ?? null
+    };
+    const prevEvents = await this.caseEventStore.getByCase(fragment.case_id, {
+      ...eventScope, limit: 2
+    });
     const prevEvent  = prevEvents.find(e => e.event_id !== event_id);
     if (prevEvent) {
       await this.caseEventStore.addEdge(event_id, prevEvent.event_id, "preceded_by").catch(() => {});
@@ -725,7 +754,7 @@ export class MemoryRememberer {
     if (eventType === "fix_attempted") {
       const errorEvents = await this.caseEventStore.getByCase(
         fragment.case_id,
-        { eventType: "error_observed", keyId }
+        { ...eventScope, eventType: "error_observed" }
       );
       for (const errEvt of errorEvents) {
         await this.caseEventStore.addEdge(event_id, errEvt.event_id, "resolved_by").catch(() => {});
@@ -906,7 +935,8 @@ export class MemoryRememberer {
           summary           : (existing.content || "").slice(0, 200),
           source_fragment_id: existing.id,
           entity_keys       : existing.keywords || [],
-          key_id            : keyId
+          /** master/group-peer amend도 source snapshot을 실제 소유 키로 조회한다. */
+          key_id            : existing.key_id ?? null
         }).then(({ event_id }) =>
           this.caseEventStore.addEvidence(existing.id, event_id, "produced_by").catch(() => {})
         ).catch(err => logWarn(`[MemoryRememberer] amend event recording failed: ${err.message}`));
@@ -927,7 +957,8 @@ export class MemoryRememberer {
         summary           : (params.outcome || existing.content || "").slice(0, 200),
         source_fragment_id: existing.id,
         entity_keys       : existing.keywords || [],
-        key_id            : keyId
+        /** 요청 키가 아니라 신뢰된 source fragment 소유 키를 event에 고정한다. */
+        key_id            : existing.key_id ?? null
       }).then(({ event_id }) =>
         this.caseEventStore.addEvidence(existing.id, event_id, "produced_by").catch(() => {})
       ).catch(err => logWarn(`[MemoryRememberer] case close event recording failed: ${err.message}`));

--- a/lib/memory/read/AgentScope.js
+++ b/lib/memory/read/AgentScope.js
@@ -1,0 +1,86 @@
+import { ALLOW_LEGACY_UNBOUND_AGENT_SCOPE } from "../../config.js";
+import { legacyUnboundAgentScopeTotal } from "../../metrics.js";
+import { logWarn } from "../../logger.js";
+
+/**
+ * 에이전트 읽기 범위의 단일 계약.
+ *
+ * - agentId 미지정: default 공유 기억만
+ * - agentId 지정: 해당 agent + default 공유 기억
+ * - includePeerAgents: 모든 agent (신뢰된 _isMaster=true가 있어야 허용)
+ */
+export function resolveAgentScope({ agentId, includePeerAgents = false, _isMaster = false } = {}) {
+  if (typeof agentId === "string" && agentId.length > 128) {
+    const err = new Error("agentId must contain at most 128 characters");
+    err.code = "INVALID_PARAMS";
+    throw err;
+  }
+  if (includePeerAgents === true && _isMaster !== true) {
+    const err = new Error("peer-agent reads are master-key only");
+    err.code = "FORBIDDEN";
+    throw err;
+  }
+  const effectiveAgentId = typeof agentId === "string" && agentId.trim()
+    ? agentId.trim()
+    : "default";
+  const peer = includePeerAgents === true;
+  return Object.freeze({
+    _isMaster       : _isMaster === true,
+    agentId          : effectiveAgentId,
+    includePeerAgents: peer,
+    agentIds         : peer
+      ? null
+      : [...new Set([effectiveAgentId, "default"])],
+    auditLabel       : peer
+      ? "all-agents"
+      : (effectiveAgentId === "default" ? "default-only" : "specific+default")
+  });
+}
+
+/** fragment 객체에 effective-agent 계약을 적용한다. */
+export function isFragmentInAgentScope(fragment, scope) {
+  if (!fragment) return false;
+  if (scope.includePeerAgents) return true;
+  /** 캐시/수화 객체에 agent metadata가 없으면 private 여부를 증명할 수 없다. */
+  if (typeof fragment.agent_id !== "string" || fragment.agent_id.length === 0) return false;
+  return scope.agentIds.includes(fragment.agent_id);
+}
+
+/**
+ * SQL WHERE 조건을 만든다. scalar agentId placeholder를 유지하여 기존 쿼리의
+ * 파라미터 순서를 바꾸지 않는다.
+ */
+export function agentScopeCondition(paramRef, scope, col = "agent_id") {
+  return scope.includePeerAgents
+    /** 호출부의 parameter index 계약은 유지하되 agent 컬럼 필터는 의도적으로 해제한다. */
+    ? `COALESCE(${paramRef}::text, 'default') IS NOT NULL /* peer-agent: no ${col} filter */`
+    : `(${col} = ${paramRef} OR ${col} = 'default')`;
+}
+
+/** API-key 요청에서 peer 범위가 요청되면 권한 오류를 발생시킨다. */
+export function assertMasterPeerScope(params = {}) {
+  if (params.includePeerAgents === true && params._isMaster !== true) {
+    const err = new Error("peer-agent reads are master-key only");
+    err.code = "FORBIDDEN";
+    throw err;
+  }
+  return resolveAgentScope(params);
+}
+
+/** 일반 API key는 서버에 바인딩된 agent identity 밖의 범위를 지정할 수 없다. */
+export function assertAuthenticatedAgentScope(params = {}, {
+  allowLegacyUnbound = ALLOW_LEGACY_UNBOUND_AGENT_SCOPE
+} = {}) {
+  if (params._isMaster === true) return resolveAgentScope(params);
+  const scope = resolveAgentScope(params);
+  if (scope.agentId !== "default" && allowLegacyUnbound !== true) {
+    const err = new Error("agentId is not authorized for this API key");
+    err.code = "FORBIDDEN";
+    throw err;
+  }
+  if (scope.agentId !== "default") {
+    legacyUnboundAgentScopeTotal.inc();
+    logWarn("Legacy unbound agent scope compatibility used; set MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE=false to enforce strict agent identity");
+  }
+  return scope;
+}

--- a/lib/memory/read/AgentScope.js
+++ b/lib/memory/read/AgentScope.js
@@ -40,9 +40,9 @@ export function resolveAgentScope({ agentId, includePeerAgents = false, _isMaste
 /** fragment 객체에 effective-agent 계약을 적용한다. */
 export function isFragmentInAgentScope(fragment, scope) {
   if (!fragment) return false;
-  if (scope.includePeerAgents) return true;
   /** 캐시/수화 객체에 agent metadata가 없으면 private 여부를 증명할 수 없다. */
   if (typeof fragment.agent_id !== "string" || fragment.agent_id.length === 0) return false;
+  if (scope.includePeerAgents) return true;
   return scope.agentIds.includes(fragment.agent_id);
 }
 
@@ -52,8 +52,8 @@ export function isFragmentInAgentScope(fragment, scope) {
  */
 export function agentScopeCondition(paramRef, scope, col = "agent_id") {
   return scope.includePeerAgents
-    /** 호출부의 parameter index 계약은 유지하되 agent 컬럼 필터는 의도적으로 해제한다. */
-    ? `COALESCE(${paramRef}::text, 'default') IS NOT NULL /* peer-agent: no ${col} filter */`
+    /** identity 범위만 완화한다. 귀속 불명(NULL) legacy row는 계속 fail-closed한다. */
+    ? `(${col} IS NOT NULL AND COALESCE(${paramRef}::text, 'default') IS NOT NULL) /* peer-agent: no ${col} filter */`
     : `(${col} = ${paramRef} OR ${col} = 'default')`;
 }
 

--- a/lib/memory/read/CaseRecall.js
+++ b/lib/memory/read/CaseRecall.js
@@ -14,6 +14,7 @@ import { keyScopeGroup } from "../keyScope.js";
 import { SCHEMA } from "../schema.js";
 import { normalizeIsAnchor } from "./SearchScope.js";
 import { workspaceCondition } from "./WorkspaceScope.js";
+import { agentScopeCondition, resolveAgentScope } from "./AgentScope.js";
 
 /** 응답 크기 방어 상한 */
 const HARD_MAX_CASES        = 10;
@@ -49,11 +50,15 @@ export class CaseRecall {
       allWorkspaces = false,
       maxCases = 5,
       isAnchor,
-      includeSuperseded = false
+      includeSuperseded = false,
+      agentId = "default",
+      includePeerAgents = false,
+      _isMaster = false
     } = {}
   ) {
     isAnchor = normalizeIsAnchor(isAnchor);
     const effectiveKeyIds = groupKeyIds ?? (keyId != null ? [keyId] : null);
+    const agentScope = resolveAgentScope({ agentId, includePeerAgents, _isMaster });
     const pool = getPrimaryPool();
     if (!pool) {
       logWarn("[CaseRecall] DB pool unavailable — returning empty cases");
@@ -80,7 +85,7 @@ export class CaseRecall {
      * 2. 각 case의 대표 파편에서 goal/outcome/resolution_status 조회.
      * fragment_count도 동일 WHERE 범위를 세어 필터가 적용된 대표 후보 수를 뜻한다.
      */
-    const queryParams = [topCaseIds];
+    const queryParams = [topCaseIds, agentScope.agentId];
     const keyFilter = keyScopeGroup(queryParams, "key_id", effectiveKeyIds).trimStart();
     const workspaceClause = workspaceCondition(
       queryParams, { workspace, allWorkspaces }, "workspace"
@@ -101,6 +106,7 @@ export class CaseRecall {
            FROM ${SCHEMA}.fragments
           WHERE case_id = ANY($1)
             ${validFilter}
+            AND ${agentScopeCondition("$2", agentScope)}
             ${keyFilter}
             ${workspaceFilter}
             ${anchorFilter}
@@ -119,16 +125,25 @@ export class CaseRecall {
      * isAnchor는 현재 대표 파편을 고르는 검색 조건이지 과거 이벤트의 속성이 아니다.
      * 이벤트를 source fragment의 현재 is_anchor/valid_to와 조인해 거르면 파편의
      * 승격·강등·대체 때 이미 기록된 타임라인까지 달라진다. 선택된 case의 이벤트는
-     * 독립적인 이력으로 유지하고 case_events 자체의 key group scope만 적용한다.
+     * 독립적인 이력으로 유지하고 case_events 자체의 immutable agent/key/workspace
+     * snapshot에만 범위를 적용한다. source fragment JOIN은 사용하지 않는다.
      */
     let events = [];
     try {
-      const eventParams = [topCaseIds];
+      const eventParams = [topCaseIds, agentScope.agentId];
       const eventKeyFilter = keyScopeGroup(eventParams, "ce.key_id", effectiveKeyIds).trimStart();
+      const eventWorkspaceClause = workspaceCondition(
+        eventParams, { workspace, allWorkspaces }, "ce.workspace"
+      );
+      const eventWorkspaceFilter = eventWorkspaceClause
+        ? `AND ${eventWorkspaceClause}`
+        : "";
       const eventQuery = `SELECT ce.case_id, ce.event_type, ce.summary, ce.created_at
            FROM ${SCHEMA}.case_events ce
           WHERE ce.case_id = ANY($1)
+            AND ${agentScopeCondition("$2", agentScope, "ce.agent_id")}
             ${eventKeyFilter}
+            ${eventWorkspaceFilter}
           ORDER BY case_id, sequence_no ASC`;
       const { rows } = await pool.query(eventQuery, eventParams);
       events = rows;

--- a/lib/memory/read/ContextBuilder.js
+++ b/lib/memory/read/ContextBuilder.js
@@ -18,6 +18,7 @@ import { SCHEMA } from "../schema.js";
 import { byDescendingScore, compareTimestampDescThenId } from "./DeterministicRanking.js";
 import { SearchScope } from "./SearchScope.js";
 import { resolveWorkspaceScope } from "./WorkspaceScope.js";
+import { agentScopeCondition, isFragmentInAgentScope, resolveAgentScope } from "./AgentScope.js";
 
 /**
  * context 응답에 포함할 힌트를 생성한다.
@@ -502,7 +503,8 @@ export class ContextBuilder {
    * @returns {Object} { fragments, totalTokens, injectionText, coreTokens, wmTokens, wmCount }
    */
   async build(params) {
-    const agentId     = params.agentId || "default";
+    const agentScope  = resolveAgentScope(params);
+    const agentId     = agentScope.agentId;
     const keyId       = params._keyId ?? null;
     const groupKeyIds = params._groupKeyIds ?? (keyId ? [keyId] : null);
     const { workspace, allWorkspaces, mode: workspaceMode } = resolveWorkspaceScope(params);
@@ -513,13 +515,13 @@ export class ContextBuilder {
       );
 
     const { wmFragments } = await this.#loadWorkingMemory(
-      params, workspace, allWorkspaces
+      params, agentScope, workspace, allWorkspaces, keyId, groupKeyIds
     );
 
     const { fragments: anchorFragments, meta: anchorSelection } =
-      await this.#loadAnchorMemory(groupKeyIds, workspace, allWorkspaces);
+      await this.#loadAnchorMemory(groupKeyIds, workspace, allWorkspaces, agentScope);
     const learningFragments = await this.#loadLearningFragments(
-      agentId, keyId, workspace, allWorkspaces
+      agentScope, groupKeyIds, workspace, allWorkspaces
     );
     const guaranteedCoreFragments = selectGuaranteedCoreFragments(
       types, typeFragMap, anchorFragments
@@ -666,9 +668,10 @@ export class ContextBuilder {
       agentId,
       _keyId: keyId,
       _groupKeyIds: groupKeyIds,
-      _isMaster: params._isMaster === true,
+      ...(params._isMaster === true ? { _isMaster: true } : {}),
       workspace,
-      allWorkspaces
+      allWorkspaces,
+      includePeerAgents: params.includePeerAgents === true
     };
 
     await Promise.all(types.map(async type => {
@@ -705,14 +708,29 @@ export class ContextBuilder {
    *
    * @returns {{ wmFragments: object[], wmChars: number }}
    */
-  async #loadWorkingMemory(params, workspace, allWorkspaces) {
+  async #loadWorkingMemory(params, agentScope, workspace, allWorkspaces, keyId, groupKeyIds) {
     const wmBudget  = 800;
     let wmFragments = [];
     let wmChars     = 0;
 
     if (params.sessionId) {
-      const wmScope = new SearchScope({ workspace, allWorkspaces });
+      const wmScope = new SearchScope({
+        agentId: agentScope.agentId,
+        ...(agentScope._isMaster === true ? { _isMaster: true } : {}),
+        includePeerAgents: agentScope.includePeerAgents,
+        workspace,
+        allWorkspaces
+      });
       const wmItems = [...await this.#index.getWorkingMemory(params.sessionId)]
+        .filter(item => isFragmentInAgentScope(item, agentScope))
+        .filter(item => {
+          if (keyId === null) return true;
+          if (item.key_id == null) return false;
+          const allowed = Array.isArray(groupKeyIds) && groupKeyIds.length > 0
+            ? groupKeyIds
+            : [keyId];
+          return allowed.map(String).includes(String(item.key_id));
+        })
         /** 구버전 Redis entry는 workspace가 없어 안전하게 판정할 수 없다. */
         .filter(item => allWorkspaces || Object.hasOwn(item, "workspace"))
         .filter(item => wmScope.applyTo(item))
@@ -741,9 +759,11 @@ export class ContextBuilder {
    *
    * @param {string[]|null} groupKeyIds
    * @param {string|null} workspace - 지정 시 동일 workspace와 전역(NULL) 앵커만 허용
+   * @param {boolean} allWorkspaces - master가 명시한 전체 workspace 조회 여부
+   * @param {object} agentScope - 적용할 agent 범위
    * @returns {{fragments: object[], meta: object}}
    */
-  async #loadAnchorMemory(groupKeyIds, workspace, allWorkspaces) {
+  async #loadAnchorMemory(groupKeyIds, workspace, allWorkspaces, agentScope) {
     const maxAnchors = MEMORY_CONFIG.contextInjection?.maxAnchorFragments ?? 20;
     const reserve    = MEMORY_CONFIG.contextInjection?.workspaceAnchorReserve ?? 10;
     const empty = (failed = false) => selectAnchorFragments([], [], {
@@ -765,7 +785,7 @@ export class ContextBuilder {
       // 조회 실패와 구분해 partial/loadStatus를 성공 상태로 유지한다.
       if (!pool) return empty();
       const queryCandidates = async ({ workspaceValue, scope }) => {
-        const anchorParams    = [];
+        const anchorParams    = [agentScope.agentId];
         const anchorKeyFilter = keyScopeGroup(anchorParams, "key_id", groupKeyIds).trimStart();
         let anchorWorkspaceFilter;
         if (scope === "global") {
@@ -784,6 +804,7 @@ export class ContextBuilder {
              FROM ${SCHEMA}.fragments
             WHERE is_anchor = TRUE
               AND valid_to IS NULL
+              AND ${agentScopeCondition("$1", agentScope)}
               ${anchorKeyFilter}
               ${anchorWorkspaceFilter}
             ORDER BY importance DESC, created_at DESC NULLS LAST, id COLLATE "C" ASC
@@ -844,14 +865,20 @@ export class ContextBuilder {
   /**
    * non-anchor Learning 파편을 별도 섹션 후보로 로드한다 (Closed Learning Loop).
    */
-  async #loadLearningFragments(agentId, keyId, workspace, allWorkspaces) {
+  async #loadLearningFragments(agentScope, keyIds, workspace, allWorkspaces) {
     try {
       return await this.#store.searchBySource(
         "learning_extraction",
-        agentId,
-        keyId,
+        agentScope.agentId,
+        keyIds,
         5,
-        { workspace, allWorkspaces, isAnchor: false }
+        {
+          workspace,
+          allWorkspaces,
+          isAnchor: false,
+          ...(agentScope._isMaster === true ? { _isMaster: true } : {}),
+          includePeerAgents: agentScope.includePeerAgents
+        }
       );
     } catch {
       return [];

--- a/lib/memory/read/FragmentReader.js
+++ b/lib/memory/read/FragmentReader.js
@@ -84,6 +84,34 @@ function scopedPointWorkspaceCondition(params, opts = {}, column = "workspace") 
 
 export class FragmentReader {
 
+  /** 관리용 non-default fragment inventory. content는 의도적으로 반환하지 않는다. */
+  async inventoryNonDefaultFragments({ workspace = null, agentId = null, anchorsOnly = true } = {}) {
+    const params = [];
+    const conditions = ["valid_to IS NULL", "agent_id <> 'default'"];
+    if (anchorsOnly) conditions.unshift("is_anchor = TRUE");
+    if (workspace) {
+      params.push(workspace);
+      conditions.push(`workspace = $${params.length}`);
+    }
+    if (agentId) {
+      params.push(agentId);
+      conditions.push(`agent_id = $${params.length}`);
+    }
+    const { rows } = await queryWithAgentVector(
+      "admin",
+      `SELECT id, agent_id, workspace, key_id, is_anchor
+         FROM ${SCHEMA}.fragments
+        WHERE ${conditions.join(" AND ")}
+        ORDER BY workspace NULLS FIRST, agent_id, id`,
+      params
+    );
+    return rows;
+  }
+
+  inventoryNonDefaultAnchors(opts = {}) {
+    return this.inventoryNonDefaultFragments({ ...opts, anchorsOnly: true });
+  }
+
   /**
    * ID로 파편 조회
    *

--- a/lib/memory/read/FragmentReader.js
+++ b/lib/memory/read/FragmentReader.js
@@ -15,6 +15,8 @@ import { logWarn }                                                from "../../lo
 import { SCHEMA } from "../schema.js";
 import { byDescendingScore, deterministicOrderBy } from "./DeterministicRanking.js";
 import { appendWorkspaceCondition, workspaceCondition } from "./WorkspaceScope.js";
+import { agentScopeCondition, resolveAgentScope } from "./AgentScope.js";
+import { normalizeIsAnchor } from "./SearchScope.js";
 
 /**
  * 검색 메서드(searchByKeywords / searchByTopic / searchBySemantic / searchByTimeRange)의
@@ -68,6 +70,18 @@ function appendAffectCondition(conditions, params, affect, paramIdx, col) {
   return paramIdx;
 }
 
+/**
+ * ID point lookup은 amend/forget/link 같은 기존 내부 처리 경로에서도 공유한다.
+ * 이 호출들은 workspace 옵션을 전달하지 않으므로 검색 기본값(global-only)을
+ * 암묵 적용하면 named-workspace 파편을 수정할 수 없게 된다. 공개 scoped read는
+ * 해석된 workspace를 null까지 own-property로 전달하므로 그 경우에만 필터한다.
+ */
+function scopedPointWorkspaceCondition(params, opts = {}, column = "workspace") {
+  const explicitScope = Object.prototype.hasOwnProperty.call(opts, "workspace")
+    || Object.prototype.hasOwnProperty.call(opts, "allWorkspaces");
+  return explicitScope ? workspaceCondition(params, opts, column) : "";
+}
+
 export class FragmentReader {
 
   /**
@@ -85,18 +99,19 @@ export class FragmentReader {
    * 소비하는 항상 참 조건으로 대체한다.
    *
    * @param {string}  paramRef          - agentId가 바인딩된 플레이스홀더 (예: "$2")
-   * @param {boolean} includePeerAgents
+   * @param {string}  agentId           - paramRef에 실제로 바인딩되는 agentId
+   * @param {Object} opts - includePeerAgents and trusted _isMaster
    * @param {string}  [col="agent_id"]  - 컬럼 표현식 (예: "f.agent_id")
    * @returns {string}
    */
-  #agentScopeCond(paramRef, includePeerAgents, col = "agent_id") {
-    return includePeerAgents
-      ? `${paramRef}::text IS NOT NULL`
-      : `(${col} = ${paramRef} OR ${col} = 'default')`;
+  #agentScopeCond(paramRef, agentId, opts, col = "agent_id") {
+    return agentScopeCondition(paramRef, resolveAgentScope({
+      ...opts, agentId
+    }), col);
   }
 
   async getById(id, agentId = "default", keyId = null, groupKeyIds = [], opts = {}) {
-    const agentCond = this.#agentScopeCond("$2", opts.includePeerAgents === true);
+    const agentCond = this.#agentScopeCond("$2", agentId, opts);
     /** includeExpired는 만료 사유 판별용이다. 일반 조회 경로는 기본값(유효 파편만)을 유지한다. */
     const validCond = opts.includeExpired === true ? "" : " AND valid_to IS NULL";
     const baseWhere = `id = $1 AND ${agentCond}${validCond}`;
@@ -104,14 +119,16 @@ export class FragmentReader {
 
     /** keyId가 있으면 SQL 레벨에서 소유권 필터 적용 */
     const keyFilter = keyScopeClause(params, "key_id", { keyId, groupKeyIds });
+    const workspaceClause = scopedPointWorkspaceCondition(params, opts, "workspace");
+    const workspaceFilter = workspaceClause ? ` AND ${workspaceClause}` : "";
 
     const result = await queryWithAgentVector(agentId,
       `SELECT id, content, topic, keywords, type, importance, utility_score,
                     source, linked_to, agent_id, access_count,
                     accessed_at, created_at, ttl_tier, verified_at, is_anchor, key_id,
-                    context_summary, session_id, valid_to,
+                    context_summary, session_id, valid_to, workspace,
                     case_id, goal, outcome, phase, resolution_status, assertion_status
-             FROM ${SCHEMA}.fragments WHERE ${baseWhere}${keyFilter}`,
+             FROM ${SCHEMA}.fragments WHERE ${baseWhere}${keyFilter}${workspaceFilter}`,
       params
     );
 
@@ -170,10 +187,12 @@ export class FragmentReader {
     if (ids.length === 0) return [];
 
     const params    = [ids, agentId];
-    const baseConds = ["id = ANY($1)", this.#agentScopeCond("$2", opts.includePeerAgents === true)];
+    const baseConds = ["id = ANY($1)", this.#agentScopeCond("$2", agentId, opts)];
     if (opts.includeSuperseded !== true) baseConds.push("valid_to IS NULL");
     const keyClause = keyScopeClause(params, "key_id", { keyId, groupKeyIds });
-    const whereClause = "WHERE " + baseConds.join(" AND ") + keyClause;
+    const workspaceClause = scopedPointWorkspaceCondition(params, opts, "workspace");
+    const workspaceFilter = workspaceClause ? ` AND ${workspaceClause}` : "";
+    const whereClause = "WHERE " + baseConds.join(" AND ") + keyClause + workspaceFilter;
 
     const result = await queryWithAgentVector(agentId,
       `SELECT id, content, topic, keywords, type, importance, utility_score,
@@ -202,23 +221,43 @@ export class FragmentReader {
    */
   async getHistory(fragmentId, agentId = "default", keyId = null, groupKeyIds = [], opts = {}) {
     const current = await this.getById(fragmentId, agentId, keyId, groupKeyIds, opts);
+    if (!current) {
+      return { current: null, versions: [], superseded_by_chain: [] };
+    }
 
+    const versionScope = resolveAgentScope({
+      ...opts, agentId
+    });
+    const versionParams = [fragmentId, versionScope.agentId];
+    const versionWorkspaceClause = scopedPointWorkspaceCondition(versionParams, opts, "workspace");
+    const versionWorkspaceFilter = versionWorkspaceClause ? `AND ${versionWorkspaceClause}` : "";
     const versions = await queryWithAgentVector(agentId,
       `SELECT fragment_id, content, topic, keywords, type, importance,
-              amended_by, amended_at
+              amended_by, amended_at, agent_id, workspace
        FROM ${SCHEMA}.fragment_versions
        WHERE fragment_id = $1
+         AND ${agentScopeCondition("$2", versionScope)}
+         ${versionWorkspaceFilter}
        ORDER BY amended_at DESC`,
-      [fragmentId]
+      versionParams
     );
 
+    const chainParams = [fragmentId, agentId];
+    const chainAgentCond = this.#agentScopeCond("$2", agentId, opts, "f.agent_id");
+    const chainKeyFilter = keyScopeClause(chainParams, "f.key_id", { keyId, groupKeyIds });
+    const chainWorkspaceClause = scopedPointWorkspaceCondition(chainParams, opts, "f.workspace");
+    const chainWorkspaceFilter = chainWorkspaceClause ? `AND ${chainWorkspaceClause}` : "";
     const chain = await queryWithAgentVector(agentId,
       `SELECT fl.to_id, f.content, f.created_at, f.valid_from
        FROM ${SCHEMA}.fragment_links fl
        JOIN ${SCHEMA}.fragments f ON f.id = fl.to_id
-       WHERE fl.from_id = $1 AND fl.relation_type = 'superseded_by'
+       WHERE fl.from_id = $1
+         AND fl.relation_type = 'superseded_by'
+         AND ${chainAgentCond}
+         ${chainKeyFilter}
+         ${chainWorkspaceFilter}
        ORDER BY f.created_at ASC`,
-      [fragmentId]
+      chainParams
     );
 
     return {
@@ -233,7 +272,8 @@ export class FragmentReader {
    */
   async searchByKeywords(keywords, options = {}) {
     const agentId    = options.agentId || "default";
-    const conditions = ["keywords && $1", this.#agentScopeCond("$2", options.includePeerAgents === true)];
+    const isAnchor   = normalizeIsAnchor(options.isAnchor);
+    const conditions = ["keywords && $1", this.#agentScopeCond("$2", agentId, options)];
     const params     = [keywords, agentId];
     let paramIdx     = 3;
 
@@ -252,9 +292,9 @@ export class FragmentReader {
       params.push(options.minImportance);
       paramIdx++;
     }
-    if (options.isAnchor !== undefined) {
+    if (isAnchor !== undefined) {
       conditions.push(`is_anchor = $${paramIdx}`);
-      params.push(options.isAnchor);
+      params.push(isAnchor);
       paramIdx++;
     }
 
@@ -327,7 +367,8 @@ export class FragmentReader {
    */
   async searchByTopic(topic, options = {}) {
     const agentId    = options.agentId || "default";
-    const conditions = ["topic = $1", this.#agentScopeCond("$2", options.includePeerAgents === true)];
+    const isAnchor   = normalizeIsAnchor(options.isAnchor);
+    const conditions = ["topic = $1", this.#agentScopeCond("$2", agentId, options)];
     const params     = [topic, agentId];
     let paramIdx     = 3;
 
@@ -341,9 +382,9 @@ export class FragmentReader {
       params.push(options.minImportance);
       paramIdx++;
     }
-    if (options.isAnchor !== undefined) {
+    if (isAnchor !== undefined) {
       conditions.push(`is_anchor = $${paramIdx}`);
-      params.push(options.isAnchor);
+      params.push(isAnchor);
       paramIdx++;
     }
     if (options.keyId) {
@@ -437,16 +478,16 @@ export class FragmentReader {
       allWorkspaces     = false,
       affect            = null,
       morphemeOnly      = false,
-      includePeerAgents = false,
-      isAnchor,
+      isAnchor: rawIsAnchor,
       type              = null,
       topic             = null
     } = opts;
+    const isAnchor   = normalizeIsAnchor(rawIsAnchor);
     const vecStr     = vectorToSql(queryEmbedding);
     const conditions = [
       "f.embedding IS NOT NULL",
       `1 - (f.embedding <=> $1::vector) >= $2`,
-      this.#agentScopeCond("$4", includePeerAgents === true, "f.agent_id")
+      this.#agentScopeCond("$4", agentId, opts, "f.agent_id")
     ];
     const params     = [vecStr, minSimilarity, limit, agentId];
     let   paramIdx   = 5;
@@ -543,7 +584,8 @@ export class FragmentReader {
    */
   async searchByTimeRange(from, to, options = {}) {
     const agentId    = options.agentId || "default";
-    const conditions = [this.#agentScopeCond("$1", options.includePeerAgents === true)];
+    const isAnchor   = normalizeIsAnchor(options.isAnchor);
+    const conditions = [this.#agentScopeCond("$1", agentId, options)];
     const params     = [agentId];
     let paramIdx     = 2;
 
@@ -569,9 +611,9 @@ export class FragmentReader {
 
     paramIdx = appendWorkspaceCondition(conditions, params, options, "workspace");
 
-    if (options.isAnchor !== undefined) {
+    if (isAnchor !== undefined) {
       conditions.push(`is_anchor = $${paramIdx}`);
-      params.push(options.isAnchor);
+      params.push(isAnchor);
       paramIdx++;
     }
 
@@ -639,16 +681,27 @@ export class FragmentReader {
    * @param {string}      sessionId
    * @param {string}      topic
    * @param {string|null} keyId - null: 마스터(전체), string: 해당 API 키 소유만
+   * @param {string[]}    groupKeyIds - 현재 key group 범위
+   * @param {Object}      opts - agentId/workspace 자동 case 범위
    * @returns {Promise<string|null>} 기존 case_id 또는 null
    */
-  async findCaseIdBySessionTopic(sessionId, topic, keyId = null, groupKeyIds = []) {
-    const params     = [sessionId, topic];
+  async findCaseIdBySessionTopic(
+    sessionId, topic, keyId = null, groupKeyIds = [], opts = {}
+  ) {
+    const agentScope = resolveAgentScope(opts);
+    const params     = [sessionId, topic, agentScope.agentId];
     const keyClause  = keyScopeClause(params, "key_id", { keyId, groupKeyIds });
-    const { rows } = await queryWithAgentVector("default",
+    const workspaceClause = workspaceCondition(params, {
+      workspace: opts.workspace ?? null,
+      allWorkspaces: false
+    }, "workspace");
+    const { rows } = await queryWithAgentVector(agentScope.agentId,
       `SELECT case_id FROM ${SCHEMA}.fragments
         WHERE session_id = $1 AND topic = $2
           AND case_id IS NOT NULL AND valid_to IS NULL
+          AND ${agentScopeCondition("$3", agentScope)}
           ${keyClause}
+          AND ${workspaceClause}
         LIMIT 1`,
       params
     );
@@ -662,16 +715,27 @@ export class FragmentReader {
    * @param {string}      sessionId
    * @param {string}      topic
    * @param {string|null} keyId - null: 마스터(전체), string: 해당 API 키 소유만
+   * @param {string[]}    groupKeyIds - 현재 key group 범위
+   * @param {Object}      opts - agentId/workspace 자동 case 범위
    * @returns {Promise<string[]>} error 파편 ID 배열
    */
-  async findErrorFragmentsBySessionTopic(sessionId, topic, keyId = null, groupKeyIds = []) {
-    const params     = [sessionId, topic];
+  async findErrorFragmentsBySessionTopic(
+    sessionId, topic, keyId = null, groupKeyIds = [], opts = {}
+  ) {
+    const agentScope = resolveAgentScope(opts);
+    const params     = [sessionId, topic, agentScope.agentId];
     const keyClause  = keyScopeClause(params, "key_id", { keyId, groupKeyIds });
-    const { rows } = await queryWithAgentVector("default",
+    const workspaceClause = workspaceCondition(params, {
+      workspace: opts.workspace ?? null,
+      allWorkspaces: false
+    }, "workspace");
+    const { rows } = await queryWithAgentVector(agentScope.agentId,
       `SELECT id FROM ${SCHEMA}.fragments
         WHERE session_id = $1 AND topic = $2
           AND type = 'error' AND valid_to IS NULL
+          AND ${agentScopeCondition("$3", agentScope)}
           ${keyClause}
+          AND ${workspaceClause}
         LIMIT 10`,
       params
     );
@@ -738,23 +802,26 @@ export class FragmentReader {
       ? { workspace: options ?? null, allWorkspaces: legacyAllWorkspaces === true }
       : options;
     const effectiveAgentId = agentId || "default";
+    const isAnchor = normalizeIsAnchor(opts.isAnchor);
     let query = `SELECT id, content, topic, type, keywords, importance, source,
                         agent_id, created_at, is_anchor, access_count, accessed_at,
                         context_summary, session_id, workspace, valid_to,
                         case_id, goal, outcome, phase, resolution_status, assertion_status
                  FROM ${SCHEMA}.fragments
-                 WHERE source = $1 AND ${this.#agentScopeCond("$2", opts.includePeerAgents === true)}`;
+                 WHERE source = $1 AND ${this.#agentScopeCond("$2", effectiveAgentId, opts)}`;
     const params = [source, effectiveAgentId];
     if (opts.includeSuperseded !== true) {
       query += " AND valid_to IS NULL";
     }
     if (keyId) {
-      query += keyScopeScalar(params, "key_id", keyId);
+      query += Array.isArray(keyId)
+        ? ` AND ${keyScopeCondition(params, "key_id", keyId)}`
+        : keyScopeScalar(params, "key_id", keyId);
     }
     const workspaceClause = workspaceCondition(params, opts, "workspace");
     if (workspaceClause) query += ` AND ${workspaceClause}`;
-    if (opts.isAnchor !== undefined) {
-      params.push(opts.isAnchor);
+    if (isAnchor !== undefined) {
+      params.push(isAnchor);
       query += ` AND is_anchor = $${params.length}`;
     }
     query += ` ${deterministicOrderBy("importance DESC")} LIMIT $${params.length + 1}`;
@@ -784,7 +851,7 @@ export class FragmentReader {
     }
     const ts         = tsDate.toISOString();
     const conditions = [
-      this.#agentScopeCond("$1", opts.includePeerAgents === true),
+      this.#agentScopeCond("$1", agentId, opts),
       "valid_from <= $2::timestamptz",
       "(valid_to IS NULL OR valid_to > $2::timestamptz)"
     ];

--- a/lib/memory/read/FragmentSearch.js
+++ b/lib/memory/read/FragmentSearch.js
@@ -337,7 +337,8 @@ export class FragmentSearch {
       resolutionStatus  : query.resolutionStatus || undefined,
       phase             : query.phase || undefined,
       affect            : query.affect || undefined,
-      includePeerAgents : query.includePeerAgents === true
+      ...(query._isMaster === true ? { _isMaster: true } : {}),
+      includePeerAgents: query.includePeerAgents === true
     };
 
     /** 질의 의도 프로파일 해석. applied=false이면 이하 모든 적용부가 항등으로 동작한다. */
@@ -462,6 +463,7 @@ export class FragmentSearch {
       {
         workspace: sq.workspace,
         allWorkspaces: sq.allWorkspaces,
+        ...(sq._isMaster === true ? { _isMaster: true } : {}),
         includePeerAgents: sq.includePeerAgents === true,
         ...(sq.includeSuperseded === true ? { includeSuperseded: true } : {}),
         ...(sq.isAnchor !== undefined ? { isAnchor: sq.isAnchor } : {})
@@ -636,7 +638,7 @@ export class FragmentSearch {
         agentId: sq.agentId, keyId: sq.keyId, workspace: sq.workspace,
         allWorkspaces: sq.allWorkspaces, limit: 30,
         includeSuperseded: sq.includeSuperseded === true,
-        ...(sq.includePeerAgents === true ? { includePeerAgents: true } : {}),
+        ...(sq.includePeerAgents === true ? { includePeerAgents: true, _isMaster: sq._isMaster === true } : {}),
         ...(sq.caseId           ? { caseId: sq.caseId } : {}),
         ...(sq.resolutionStatus ? { resolutionStatus: sq.resolutionStatus } : {}),
         ...(sq.phase            ? { phase: sq.phase } : {}),
@@ -763,7 +765,7 @@ export class FragmentSearch {
       ...(query.resolutionStatus ? { resolutionStatus: query.resolutionStatus } : {}),
       ...(query.phase            ? { phase: query.phase } : {}),
       ...(query.affect           ? { affect: query.affect } : {}),
-      ...(query.includePeerAgents === true ? { includePeerAgents: true } : {})
+      ...(query.includePeerAgents === true ? { includePeerAgents: true, _isMaster: query._isMaster === true } : {})
     };
 
     let results = [];
@@ -804,6 +806,7 @@ export class FragmentSearch {
 
       if (missingIds.length > 0) {
         let fetched = await this.store.getByIds(missingIds, agentId, keyId, [], {
+          ...(query._isMaster === true ? { _isMaster: true } : {}),
           includePeerAgents: query.includePeerAgents === true,
           includeSuperseded: query.includeSuperseded === true
         });
@@ -880,6 +883,7 @@ export class FragmentSearch {
             allWorkspaces    : query.allWorkspaces === true,
             affect           : null,
             morphemeOnly     : true,
+            ...(query._isMaster === true ? { _isMaster: true } : {}),
             includePeerAgents: query.includePeerAgents === true,
             ...(query.isAnchor !== undefined ? { isAnchor: query.isAnchor } : {}),
             type             : query.type ?? null,
@@ -903,6 +907,8 @@ export class FragmentSearch {
             minSimilarity,
             includeSuperseded: query.includeSuperseded === true,
             ...(query.isAnchor !== undefined ? { isAnchor: query.isAnchor } : {}),
+            ...(query._isMaster === true ? { _isMaster: true } : {}),
+            includePeerAgents: query.includePeerAgents === true,
           }).catch(() => [])
         : Promise.resolve([]);
 
@@ -917,6 +923,7 @@ export class FragmentSearch {
           allWorkspaces    : query.allWorkspaces === true,
           affect           : query.affect ?? null,
           morphemeOnly     : false,
+          ...(query._isMaster === true ? { _isMaster: true } : {}),
           includePeerAgents: query.includePeerAgents === true,
           ...(query.isAnchor !== undefined ? { isAnchor: query.isAnchor } : {}),
           type             : query.type ?? null,

--- a/lib/memory/read/GraphNeighborSearch.js
+++ b/lib/memory/read/GraphNeighborSearch.js
@@ -13,6 +13,7 @@ import { MEMORY_CONFIG }   from "../../../config/memory.js";
 import { SCHEMA } from "../schema.js";
 import { byDescendingScore } from "./DeterministicRanking.js";
 import { workspaceCondition } from "./WorkspaceScope.js";
+import { resolveAgentScope } from "./AgentScope.js";
 
 /**
  * L2 상위 파편 ID에서 1-hop 이웃 파편을 조회한다.
@@ -36,6 +37,7 @@ export async function fetchGraphNeighbors(
   keyId = null,
   opts = {}
 ) {
+  resolveAgentScope({ ...opts, agentId });
   if (!seedIds || seedIds.length === 0) return [];
 
   const validIds = seedIds.filter(id => typeof id === "string" && id.length > 0);

--- a/lib/memory/read/HistoryReconstructor.js
+++ b/lib/memory/read/HistoryReconstructor.js
@@ -14,6 +14,8 @@ import { getPrimaryPool } from "../../tools/db.js";
 import { logWarn }        from "../../logger.js";
 import { keyScopeClause } from "../keyScope.js";
 import { SCHEMA } from "../schema.js";
+import { agentScopeCondition, resolveAgentScope } from "./AgentScope.js";
+import { resolveWorkspaceScope, workspaceCondition } from "./WorkspaceScope.js";
 
 /** LIKE 패턴 내 와일드카드 문자(%, _, \) 이스케이프 */
 function escapeLike(str) {
@@ -62,34 +64,45 @@ export class HistoryReconstructor {
     const limit       = Math.min(params.limit ?? 100, 500);
     const keyId       = params.keyId        ?? null;
     const groupKeyIds = params.groupKeyIds  ?? (keyId != null ? [keyId] : []);
-    const workspace   = params.workspace    ?? null;
+    const { workspace, allWorkspaces } = resolveWorkspaceScope(params);
+    const agentScope  = resolveAgentScope(params);
 
     if (!caseId && !entity) {
       throw new Error("caseId 또는 entity 중 하나는 필수입니다.");
     }
 
-    const timeline = await this._fetchTimelineParameterized({ caseId, entity, timeRange, query, limit, keyId, groupKeyIds, workspace });
+    const timeline = await this._fetchTimelineParameterized({
+      caseId, entity, timeRange, query, limit, keyId, groupKeyIds, workspace,
+      allWorkspaces,
+      agentId: agentScope.agentId, includePeerAgents: agentScope.includePeerAgents, _isMaster: agentScope._isMaster
+    });
 
     /** case_events / DAG: caseEventStore 주입 + caseId가 있을 때만 조회 */
     let case_events = [];
     let event_dag   = [];
+    const eventScope = {
+      keyId, groupKeyIds, workspace, allWorkspaces,
+      agentId: agentScope.agentId,
+      _isMaster: agentScope._isMaster,
+      includePeerAgents: agentScope.includePeerAgents
+    };
 
     if (this.caseEventStore && caseId) {
-      case_events = await this.caseEventStore.getByCase(caseId, { keyId }).catch(err => {
+      case_events = await this.caseEventStore.getByCase(caseId, eventScope).catch(err => {
         logWarn(`[HistoryReconstructor] getByCase failed: ${err?.message}`);
         return [];
       });
 
       if (case_events.length > 0) {
         const eventIds = case_events.map(e => e.event_id);
-        event_dag      = await this.caseEventStore.getEdgesByEvents(eventIds, keyId).catch(() => []);
+        event_dag      = await this.caseEventStore.getEdgesByEvents(eventIds, eventScope).catch(() => []);
       }
     }
 
     /** 각 이벤트에 근거 파편(evidence) 첨부 */
     if (case_events.length > 0 && this.caseEventStore) {
       await Promise.all(case_events.map(async (evt) => {
-        evt.evidence = await this.caseEventStore.getEvidenceByEvent(evt.event_id, keyId).catch(() => []);
+        evt.evidence = await this.caseEventStore.getEvidenceByEvent(evt.event_id, eventScope).catch(() => []);
       }));
     }
 
@@ -106,7 +119,7 @@ export class HistoryReconstructor {
     }
 
     const fragmentIds = timeline.map(f => f.id);
-    const links       = await this._fetchLinks(fragmentIds);
+    const links       = await this._fetchLinks(fragmentIds, eventScope);
 
     const causal_chains       = this._buildCausalChains(timeline, links, event_dag);
     const unresolved_branches = this._detectUnresolvedBranches(timeline, causal_chains, case_events, event_dag);
@@ -135,19 +148,26 @@ export class HistoryReconstructor {
    *
    * @private
    */
-  async _fetchTimelineParameterized({ caseId, entity, timeRange, query, limit, keyId, groupKeyIds, workspace }) {
+  async _fetchTimelineParameterized({
+    caseId, entity, timeRange, query, limit, keyId, groupKeyIds,
+    workspace, allWorkspaces, agentId, includePeerAgents, _isMaster
+  }) {
     const pool   = getPrimaryPool();
     const params = [];
+    const agentScope = resolveAgentScope({ agentId, includePeerAgents, _isMaster });
+    params.push(agentScope.agentId);
+    const agentIdx = params.length;
 
     /** $1: caseId 또는 entity */
     let scopeClause;
     if (caseId) {
-      params.push(caseId);                        // $1
-      scopeClause = `f.case_id = $1`;
+      params.push(caseId);
+      scopeClause = `f.case_id = $${params.length}`;
     } else {
-      params.push(`%${escapeLike(entity)}%`);       // $1
-      params.push(entity.toLowerCase());          // $2
-      scopeClause = `(f.topic ILIKE $1 OR f.keywords @> ARRAY[$2]::text[])`;
+      params.push(`%${escapeLike(entity)}%`);
+      const entityLikeIdx = params.length;
+      params.push(entity.toLowerCase());
+      scopeClause = `(f.topic ILIKE $${entityLikeIdx} OR f.keywords @> ARRAY[$${params.length}]::text[])`;
     }
 
     const _nextIdx = () => params.length + 1;
@@ -169,11 +189,8 @@ export class HistoryReconstructor {
     const keyClause = keyScopeClause(params, "f.key_id", { keyId, groupKeyIds });
 
     /** workspace 격리 */
-    let wsClause = "";
-    if (workspace) {
-      params.push(workspace);
-      wsClause = `AND (f.workspace = $${params.length} OR f.workspace IS NULL)`;
-    }
+    const wsFilter = workspaceCondition(params, { workspace, allWorkspaces }, "f.workspace");
+    const wsClause = wsFilter ? `AND ${wsFilter}` : "";
 
     /** limit */
     params.push(limit);
@@ -185,6 +202,7 @@ export class HistoryReconstructor {
              f.phase, f.assertion_status, f.workspace, f.agent_id, f.created_at
         FROM ${SCHEMA}.fragments f
        WHERE ${scopeClause}
+         AND ${agentScopeCondition(`$${agentIdx}`, agentScope, "f.agent_id")}
          AND ($${fromIdx}::timestamptz IS NULL OR f.created_at >= $${fromIdx})
          AND ($${toIdx}::timestamptz   IS NULL OR f.created_at <= $${toIdx})
          ${queryClause}
@@ -205,16 +223,39 @@ export class HistoryReconstructor {
    * @param {string[]} fragmentIds
    * @returns {Promise<Object[]>}
    */
-  async _fetchLinks(fragmentIds) {
+  async _fetchLinks(fragmentIds, opts = {}) {
     if (!fragmentIds || fragmentIds.length === 0) return [];
 
-    const pool         = getPrimaryPool();
-    const { rows }     = await pool.query(
+    const pool = getPrimaryPool();
+    const agentScope = resolveAgentScope(opts);
+    const params = [fragmentIds, agentScope.agentId];
+    const clauses = [
+      agentScopeCondition("$2", agentScope, "f_from.agent_id"),
+      agentScopeCondition("$2", agentScope, "f_to.agent_id")
+    ];
+    for (const alias of ["f_from.key_id", "f_to.key_id"]) {
+      const keyClause = keyScopeClause(params, alias, {
+        keyId: opts.keyId ?? null, groupKeyIds: opts.groupKeyIds
+      });
+      if (keyClause) clauses.push(keyClause.trim().replace(/^AND\s+/, ""));
+    }
+    const workspaceScope = resolveWorkspaceScope(opts);
+    if (!workspaceScope.allWorkspaces && workspaceScope.workspace === null) {
+      clauses.push("f_from.workspace IS NULL", "f_to.workspace IS NULL");
+    } else if (!workspaceScope.allWorkspaces) {
+      params.push(workspaceScope.workspace);
+      clauses.push(`(f_from.workspace = $${params.length} OR f_from.workspace IS NULL)`);
+      clauses.push(`(f_to.workspace = $${params.length} OR f_to.workspace IS NULL)`);
+    }
+    const extra = clauses.length > 0 ? `AND ${clauses.join(" AND ")}` : "";
+    const { rows } = await pool.query(
       `SELECT fl.from_id, fl.to_id, fl.relation_type, fl.weight
          FROM ${SCHEMA}.fragment_links fl
-        WHERE fl.from_id = ANY($1)
-           OR fl.to_id   = ANY($1)`,
-      [fragmentIds]
+         JOIN ${SCHEMA}.fragments f_from ON f_from.id = fl.from_id
+         JOIN ${SCHEMA}.fragments f_to   ON f_to.id   = fl.to_id
+        WHERE (fl.from_id = ANY($1) OR fl.to_id = ANY($1))
+          ${extra}`,
+      params
     );
     return rows;
   }

--- a/lib/memory/read/LinkedFragmentLoader.js
+++ b/lib/memory/read/LinkedFragmentLoader.js
@@ -11,13 +11,15 @@ import { getPrimaryPool } from "../../tools/db.js";
 import { SCHEMA } from "../schema.js";
 import { keyScopeClause } from "../keyScope.js";
 import { workspaceCondition } from "./WorkspaceScope.js";
+import { agentScopeCondition, resolveAgentScope } from "./AgentScope.js";
 
 /**
  * 주어진 파편 ID 배열에 대해 1-hop 연결 파편을 조회한다.
  *
  * @param {string[]} fragmentIds - 조회 대상 파편 ID 배열
- * @param {{keyId?: string|null, groupKeyIds?: string[], workspace?: string|null,
- *   allWorkspaces?: boolean, isAnchor?: boolean, includeSuperseded?: boolean}} [scope]
+ * @param {{agentId?: string, includePeerAgents?: boolean, keyId?: string|null,
+ *   groupKeyIds?: string[], workspace?: string|null, allWorkspaces?: boolean,
+ *   isAnchor?: boolean, includeSuperseded?: boolean}} [scope]
  *   true=앵커만, false=비앵커만, 미지정=혼합. includeSuperseded=true이면 만료 파편도 허용.
  * @returns {Promise<Map<string, Array<{id: string, relation_type: string, preview: string}>>>}
  *          from_id -> [linked fragment] (최대 3개씩)
@@ -26,14 +28,10 @@ export async function fetchLinkedFragments(fragmentIds, scope = {}) {
   if (!fragmentIds || fragmentIds.length === 0) return new Map();
 
   const pool = getPrimaryPool();
-
-  /**
-   * LATERAL JOIN으로 from_id별 상위 3개를 효율적으로 가져온다.
-   * weight DESC로 가장 강한 관계부터 반환.
-   */
-  const params       = [fragmentIds];
+  const agentScope = resolveAgentScope(scope);
+  const params = [fragmentIds, agentScope.agentId];
   const keyClause = keyScopeClause(params, "f.key_id", {
-    keyId: scope.keyId ?? null,
+    keyId      : scope.keyId ?? null,
     groupKeyIds: scope.groupKeyIds
   });
   const workspaceFilter = workspaceCondition(params, scope, "f.workspace");
@@ -50,8 +48,9 @@ export async function fetchLinkedFragments(fragmentIds, scope = {}) {
            FROM ${SCHEMA}.fragment_links fl
            JOIN ${SCHEMA}.fragments f ON f.id = fl.to_id
           WHERE fl.from_id = fid.id
-            ${validClause}${keyClause}${workspaceClause}
-            ${anchorClause}
+            ${validClause}
+            AND ${agentScopeCondition("$2", agentScope, "f.agent_id")}
+            ${keyClause}${workspaceClause}${anchorClause}
           ORDER BY fl.weight DESC
           LIMIT 3
        ) sub`,

--- a/lib/memory/read/SearchScope.js
+++ b/lib/memory/read/SearchScope.js
@@ -16,6 +16,8 @@
  * fromQuery(sq) 정적 팩토리
  *   _buildSearchQuery()가 반환한 정규화된 sq에서 SearchScope를 생성한다.
  */
+import { isFragmentInAgentScope, resolveAgentScope } from "./AgentScope.js";
+
 /**
  * JSON Schema를 우회한 호출도 문자열 "false"를 truthy 값으로 오해하지 않도록
  * isAnchor를 명시적인 3상태로 정규화한다.
@@ -62,6 +64,7 @@ export class SearchScope {
     keyId = null,
     agentId = null,
     includePeerAgents = false,
+    _isMaster = false,
     isAnchor
   } = {}) {
     this.workspace         = workspace;
@@ -78,6 +81,8 @@ export class SearchScope {
     this.keyId             = keyId;
     this.agentId           = agentId;
     this.includePeerAgents = includePeerAgents;
+    this._isMaster = _isMaster === true;
+    resolveAgentScope({ agentId, includePeerAgents, _isMaster });
     this.isAnchor          = normalizeIsAnchor(isAnchor);
   }
 
@@ -90,12 +95,14 @@ export class SearchScope {
   applyTo(fragment) {
     if (!fragment) return false;
 
-    /** agent: SQL의 (agent_id = $agentId OR agent_id = 'default')와 동일한 계약.
-     *  agentId 미지정 또는 includePeerAgents=true면 agent 조건을 적용하지 않는다. */
-    if (this.agentId !== null && !this.includePeerAgents) {
-      if (fragment.agent_id !== this.agentId && fragment.agent_id !== "default") {
-        return false;
-      }
+    /** agent: effective-agent 공통 계약. */
+    if (this.agentId !== null) {
+      const scope = resolveAgentScope({
+        agentId          : this.agentId,
+        includePeerAgents: this.includePeerAgents,
+        _isMaster: this._isMaster
+      });
+      if (!isFragmentInAgentScope(fragment, scope)) return false;
     }
 
     /** workspace: allWorkspaces=true만 전체 허용.
@@ -179,7 +186,8 @@ export class SearchScope {
       type            : sq.type,
       topic           : sq.topic,
       keyId           : sq.keyId            ?? null,
-      agentId         : sq.agentId          ?? null,
+      agentId         : sq.agentId          ?? "default",
+      ...(sq._isMaster === true ? { _isMaster: true } : {}),
       includePeerAgents: sq.includePeerAgents === true,
       isAnchor        : sq.isAnchor
     });

--- a/lib/memory/read/StitchSourceLoader.js
+++ b/lib/memory/read/StitchSourceLoader.js
@@ -16,6 +16,7 @@ import { getPrimaryPool } from "../../tools/db.js";
 import { keyScopeClause } from "../keyScope.js";
 import { SCHEMA } from "../schema.js";
 import { workspaceCondition } from "./WorkspaceScope.js";
+import { agentScopeCondition, resolveAgentScope } from "./AgentScope.js";
 
 /** 스티칭에서 인과로 취급하는 관계 종류 */
 const CAUSAL_RELATIONS = ["caused_by", "resolved_by", "contradicts", "part_of"];
@@ -36,6 +37,8 @@ export async function fetchCausalLinks(fragmentIds, scope = {}, perFragment = 3)
   if (!pool) return new Map();
 
   const params = [fragmentIds, CAUSAL_RELATIONS];
+  const agentScope = resolveAgentScope(scope);
+  params.push(agentScope.agentId);
   const keyClause = keyScopeClause(params, "f.key_id", {
     keyId      : scope.keyId ?? null,
     groupKeyIds: scope.groupKeyIds,
@@ -60,7 +63,9 @@ export async function fetchCausalLinks(fragmentIds, scope = {}, perFragment = 3)
            JOIN ${SCHEMA}.fragments f ON f.id = fl.to_id
           WHERE fl.from_id = ANY($1::text[])
             AND fl.relation_type = ANY($2::text[])
-            ${validClause}${keyClause}${workspaceClause}${anchorClause}
+            ${validClause}
+            AND ${agentScopeCondition("$3", agentScope, "f.agent_id")}${keyClause}
+            ${workspaceClause}${anchorClause}
          UNION ALL
          SELECT fl.to_id AS anchor_id, fl.from_id AS other_id, fl.relation_type,
                 'in'::text AS direction, f.content, fl.weight
@@ -68,7 +73,9 @@ export async function fetchCausalLinks(fragmentIds, scope = {}, perFragment = 3)
            JOIN ${SCHEMA}.fragments f ON f.id = fl.from_id
           WHERE fl.to_id = ANY($1::text[])
             AND fl.relation_type = ANY($2::text[])
-            ${validClause}${keyClause}${workspaceClause}${anchorClause}
+            ${validClause}
+            AND ${agentScopeCondition("$3", agentScope, "f.agent_id")}${keyClause}
+            ${workspaceClause}${anchorClause}
        ) t
       ORDER BY weight DESC`,
     params
@@ -109,6 +116,8 @@ export async function fetchSessionNeighbors(fragments, scope = {}, windowMinutes
 
   const sessionIds = [...new Set(targets.map(f => f.session_id))];
   const params     = [sessionIds];
+  const agentScope = resolveAgentScope(scope);
+  params.push(agentScope.agentId);
   const keyClause  = keyScopeClause(params, "f.key_id", {
     keyId      : scope.keyId ?? null,
     groupKeyIds: scope.groupKeyIds,
@@ -124,7 +133,9 @@ export async function fetchSessionNeighbors(fragments, scope = {}, windowMinutes
     `SELECT f.id, f.content, f.type, f.created_at, f.session_id
        FROM ${SCHEMA}.fragments f
       WHERE f.session_id = ANY($1::text[])
-        ${validClause}${keyClause}${workspaceClause}${anchorClause}
+        ${validClause}
+        AND ${agentScopeCondition("$2", agentScope, "f.agent_id")}${keyClause}
+        ${workspaceClause}${anchorClause}
       ORDER BY f.created_at ASC`,
     params
   );

--- a/lib/memory/read/SyntheticQuerySearch.js
+++ b/lib/memory/read/SyntheticQuerySearch.js
@@ -20,6 +20,7 @@ import { SCHEMA } from "../schema.js";
 import { normalizeIsAnchor } from "./SearchScope.js";
 import { byDescendingScore } from "./DeterministicRanking.js";
 import { workspaceCondition } from "./WorkspaceScope.js";
+import { agentScopeCondition, resolveAgentScope } from "./AgentScope.js";
 
 /**
  * 키 격리 목록을 정규화한다. 스칼라와 배열 입력을 모두 받는다.
@@ -120,7 +121,8 @@ export async function searchSyntheticQueries(vec, opts = {}) {
 
   const minSimilarity = opts.minSimilarity ?? 0.2;
   const isAnchor      = normalizeIsAnchor(opts.isAnchor);
-  const params        = [JSON.stringify(vec), minSimilarity, limit * 3];
+  const agentScope    = resolveAgentScope(opts);
+  const params        = [JSON.stringify(vec), minSimilarity, limit * 3, agentScope.agentId];
 
   /** 키 격리는 시맨틱 검색 경로(FragmentReader.searchBySemantic)와 같은 표현을 쓴다.
    *  key_id = ANY(배열)은 전역(NULL) 파편도 함께 배제한다. */
@@ -140,6 +142,7 @@ export async function searchSyntheticQueries(vec, opts = {}) {
          FROM ${SCHEMA}.fragment_synthetic_query q
          JOIN ${SCHEMA}.fragments f ON f.id = q.fragment_id
         WHERE q.embedding IS NOT NULL
+          AND ${agentScopeCondition("$4", agentScope, "f.agent_id")}
           AND 1 - (q.embedding <=> $1::vector) >= $2${keyClause}${workspaceClause}${anchorClause}${validClause}
         ORDER BY q.embedding <=> $1::vector
         LIMIT $3`,
@@ -157,7 +160,7 @@ export async function searchSyntheticQueries(vec, opts = {}) {
 
   const simById = new Map(candidates.map(c => [c.id, c.similarity]));
   const idList  = candidates.map(c => c.id);
-  const fragParams    = [idList];
+  const fragParams    = [idList, agentScope.agentId];
   const fragKeyClause = keyScopeGroup(fragParams, "f.key_id", keyList);
   const fragWorkspaceFilter = workspaceCondition(fragParams, opts, "f.workspace");
   const fragWorkspaceClause = fragWorkspaceFilter ? ` AND ${fragWorkspaceFilter}` : "";
@@ -171,7 +174,8 @@ export async function searchSyntheticQueries(vec, opts = {}) {
       `SELECT f.*
         FROM ${SCHEMA}.fragments f
         WHERE f.id = ANY($1::text[])
-          ${fragKeyClause}${fragWorkspaceClause}${fragAnchorClause}${fragValidClause}`,
+          AND ${agentScopeCondition("$2", agentScope, "f.agent_id")}${fragKeyClause}
+          ${fragWorkspaceClause}${fragAnchorClause}${fragValidClause}`,
       fragParams
     );
 

--- a/lib/memory/read/TopicResolver.js
+++ b/lib/memory/read/TopicResolver.js
@@ -18,6 +18,7 @@ import { MorphemeIndex }    from "../embedding/MorphemeIndex.js";
 import { cosineSimilarity } from "../../tools/embedding.js";
 import { SCHEMA } from "../schema.js";
 import { workspaceCondition } from "./WorkspaceScope.js";
+import { agentScopeCondition, resolveAgentScope } from "./AgentScope.js";
 
 /** 유사도 평가 대상으로 끌어올 topic 집계 상한.
  *  파편 수 상위만 자르면 소규모 topic이 오기 후보에서 빠지므로 넓게 잡는다
@@ -42,7 +43,8 @@ const MIN_SIMILARITY      = 0.5;
  * @returns {Promise<Array<{topic: string, count: number}>>}
  */
 async function aggregateTopics(pool, scope, wrongTopic) {
-  const params    = [wrongTopic];
+  const agentScope = resolveAgentScope(scope);
+  const params    = [wrongTopic, agentScope.agentId];
   const keyClause = keyScopeClause(params, "key_id", {
     keyId      : scope.keyId ?? null,
     groupKeyIds: scope.groupKeyIds
@@ -55,7 +57,9 @@ async function aggregateTopics(pool, scope, wrongTopic) {
        FROM ${SCHEMA}.fragments
       WHERE valid_to IS NULL
         AND topic IS NOT NULL
-        AND topic <> $1${keyClause}${workspaceClause}
+        AND topic <> $1
+        AND ${agentScopeCondition("$2", agentScope)}${keyClause}
+        ${workspaceClause}
       GROUP BY topic
       ORDER BY count DESC
       LIMIT ${CANDIDATE_POOL_SIZE}`,

--- a/lib/memory/rollback-migration-047-agent-scope-audit.sql
+++ b/lib/memory/rollback-migration-047-agent-scope-audit.sql
@@ -1,0 +1,25 @@
+-- migration-047 수동 롤백.
+-- 주의: 이 파일은 자동 실행되지 않는다. 먼저 이 릴리스의 writer/read 경로를
+-- 이전 버전으로 되돌린 뒤 실행해야 하며 snapshot 데이터가 삭제된다.
+-- anchor-scope --execute의 fragments.agent_id 정규화는 되돌리지 않는다.
+-- 재적용/재백필은 현재 agent 값(default)을 복사하므로 정규화 전 상태를
+-- 복원하려면 실행 전 별도 백업이 필요하다.
+
+BEGIN;
+
+ALTER TABLE agent_memory.search_events
+  DROP COLUMN IF EXISTS effective_agent_scope,
+  DROP COLUMN IF EXISTS include_peer_agents;
+
+ALTER TABLE agent_memory.fragment_versions
+  DROP COLUMN IF EXISTS agent_id,
+  DROP COLUMN IF EXISTS workspace;
+
+ALTER TABLE agent_memory.case_events
+  DROP COLUMN IF EXISTS agent_id,
+  DROP COLUMN IF EXISTS workspace;
+
+DELETE FROM agent_memory.schema_migrations
+ WHERE filename = 'migration-047-agent-scope-audit.sql';
+
+COMMIT;

--- a/lib/memory/signals/SearchEventRecorder.js
+++ b/lib/memory/signals/SearchEventRecorder.js
@@ -12,6 +12,7 @@
 import { getPrimaryPool } from "../../tools/db.js";
 import { logWarn }        from "../../logger.js";
 import { SCHEMA } from "../schema.js";
+import { resolveAgentScope } from "../read/AgentScope.js";
 
 /**
  * 검색 쿼리 객체를 분석하여 쿼리 타입을 반환한다.
@@ -165,6 +166,7 @@ export function buildSearchEvent(query, result, meta = {}) {
   const l2Count  = l2Match ? parseInt(l2Match[1], 10) : 0;
   const l3Count  = l3Match ? parseInt(l3Match[1], 10) : 0;
   const usedRrf  = searchPath.includes("RRF");
+  const agentScope = resolveAgentScope(query);
 
   return {
     session_id    : meta.sessionId    ?? null,
@@ -182,7 +184,9 @@ export function buildSearchEvent(query, result, meta = {}) {
     l1_latency_ms : meta.l1LatencyMs  ?? null,
     l2_latency_ms : meta.l2LatencyMs  ?? null,
     l3_latency_ms : meta.l3LatencyMs  ?? null,
-    graph_used    : meta.graphUsed    ?? false
+    graph_used    : meta.graphUsed    ?? false,
+    effective_agent_scope: agentScope.auditLabel,
+    include_peer_agents : agentScope.includePeerAgents
   };
 }
 
@@ -200,8 +204,9 @@ export async function recordSearchEvent(event) {
     INSERT INTO ${SCHEMA}.search_events
       (session_id, key_id, search_path, l1_count, l2_count, l3_count,
        result_count, l1_is_fallback, used_rrf, latency_ms, query_type, filter_keys,
-       l1_latency_ms, l2_latency_ms, l3_latency_ms, graph_used)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+       l1_latency_ms, l2_latency_ms, l3_latency_ms, graph_used,
+       effective_agent_scope, include_peer_agents)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
     RETURNING id
   `;
 
@@ -221,7 +226,9 @@ export async function recordSearchEvent(event) {
     event.l1_latency_ms  ?? null,
     event.l2_latency_ms  ?? null,
     event.l3_latency_ms  ?? null,
-    event.graph_used     ?? false
+    event.graph_used     ?? false,
+    event.effective_agent_scope,
+    event.include_peer_agents === true
   ];
 
   try {

--- a/lib/memory/write/FragmentStore.js
+++ b/lib/memory/write/FragmentStore.js
@@ -24,6 +24,8 @@ export class FragmentStore {
   // ── Read delegations ────────────────────────────────────────────────────────
 
   getById(id, agentId, keyId, groupKeyIds, opts)                      { return this.reader.getById(id, agentId, keyId, groupKeyIds, opts); }
+  inventoryNonDefaultAnchors(opts)                                    { return this.reader.inventoryNonDefaultAnchors(opts); }
+  inventoryNonDefaultFragments(opts)                                  { return this.reader.inventoryNonDefaultFragments(opts); }
   getByIds(ids, agentId, keyId, groupKeyIds, opts)                    { return this.reader.getByIds(ids, agentId, keyId, groupKeyIds, opts); }
   probeAccess(id, agentId, keyId, groupKeyIds)                        { return this.reader.probeAccess(id, agentId, keyId, groupKeyIds); }
   getHistory(fragmentId, agentId, keyId, groupKeyIds, opts)           { return this.reader.getHistory(fragmentId, agentId, keyId, groupKeyIds, opts); }
@@ -43,7 +45,7 @@ export class FragmentStore {
 
   ensureSchema()                                                       { return this.writer.ensureSchema(); }
   insert(fragment)                                                     { return this.writer.insert(fragment); }
-  update(id, updates, agentId, keyId, existing)                       { return this.writer.update(id, updates, agentId, keyId, existing); }
+  update(id, updates, agentId, keyId, existing, opts)                 { return this.writer.update(id, updates, agentId, keyId, existing, opts); }
   delete(id, agentId, keyId)                                          { return this.writer.delete(id, agentId, keyId); }
   deleteMany(ids, agentId, keyId)                                     { return this.writer.deleteMany(ids, agentId, keyId); }
   deleteByAgent(agentId)                                              { return this.writer.deleteByAgent(agentId); }

--- a/lib/memory/write/FragmentStore.js
+++ b/lib/memory/write/FragmentStore.js
@@ -35,8 +35,8 @@ export class FragmentStore {
   searchByTimeRange(from, to, options)                                  { return this.reader.searchByTimeRange(from, to, options); }
   searchAsOf(asOf, agentId, opts, keyId)                               { return this.reader.searchAsOf(asOf, agentId, opts, keyId); }
   searchBySource(source, agentId, keyId, limit, options, allWorkspaces) { return this.reader.searchBySource(source, agentId, keyId, limit, options, allWorkspaces); }
-  findCaseIdBySessionTopic(sessionId, topic, keyId, groupKeyIds)        { return this.reader.findCaseIdBySessionTopic(sessionId, topic, keyId, groupKeyIds); }
-  findErrorFragmentsBySessionTopic(sessionId, topic, keyId, groupKeyIds) { return this.reader.findErrorFragmentsBySessionTopic(sessionId, topic, keyId, groupKeyIds); }
+  findCaseIdBySessionTopic(sessionId, topic, keyId, groupKeyIds, opts)        { return this.reader.findCaseIdBySessionTopic(sessionId, topic, keyId, groupKeyIds, opts); }
+  findErrorFragmentsBySessionTopic(sessionId, topic, keyId, groupKeyIds, opts) { return this.reader.findErrorFragmentsBySessionTopic(sessionId, topic, keyId, groupKeyIds, opts); }
   findByIdempotencyKey(idempotencyKey, keyId)                          { return this.reader.findByIdempotencyKey(idempotencyKey, keyId); }
 
   // ── Write delegations ───────────────────────────────────────────────────────
@@ -54,7 +54,7 @@ export class FragmentStore {
   archiveVersion(fragment, agentId)                                   { return this.writer.archiveVersion(fragment, agentId); }
   updateTtlTier(id, ttlTier, keyId = null)                              { return this.writer.updateTtlTier(id, ttlTier, keyId); }
   patchAssertion(id, assertionStatus, keyId = null)                    { return this.writer.patchAssertion(id, assertionStatus, keyId); }
-  updateCaseId(fragmentId, caseId, keyId)                              { return this.writer.updateCaseId(fragmentId, caseId, keyId); }
+  updateCaseId(fragmentId, caseId, keyId, opts)                        { return this.writer.updateCaseId(fragmentId, caseId, keyId, opts); }
   deleteExpired()                                                      { return this.writer.deleteExpired(); }
 
   // ── GC delegations ──────────────────────────────────────────────────────────
@@ -70,5 +70,5 @@ export class FragmentStore {
   getLinkedFragments(fromIds, relationType, agentId, keyId, opts = {}) { return this.links.getLinkedFragments(fromIds, relationType, agentId, keyId, opts); }
   getLinkedIds(fragmentId, agentId, keyId)                            { return this.links.getLinkedIds(fragmentId, agentId, keyId); }
   isReachable(startId, targetId, agentId, keyId)                      { return this.links.isReachable(startId, targetId, agentId, keyId); }
-  getRCAChain(startId, agentId, keyId, groupKeyIds)                   { return this.links.getRCAChain(startId, agentId, keyId, groupKeyIds); }
+  getRCAChain(startId, agentId, keyId, groupKeyIds, opts)             { return this.links.getRCAChain(startId, agentId, keyId, groupKeyIds, opts); }
 }

--- a/lib/memory/write/FragmentWriter.js
+++ b/lib/memory/write/FragmentWriter.js
@@ -246,10 +246,13 @@ export class FragmentWriter {
    * 파편의 현재 상태를 이력 테이블에 저장
    */
   async archiveVersion(fragment, agentId = "default") {
+    if (typeof fragment?.agent_id !== "string" || fragment.agent_id.length === 0) {
+      throw new Error("Fragment agent scope is required for version history");
+    }
     await queryWithAgentVector(agentId,
       `INSERT INTO ${SCHEMA}.fragment_versions
-                (fragment_id, content, topic, keywords, type, importance, amended_by)
-       VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+                (fragment_id, content, topic, keywords, type, importance, amended_by, agent_id, workspace)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
       [
         fragment.id,
         fragment.content,
@@ -257,7 +260,9 @@ export class FragmentWriter {
         fragment.keywords,
         fragment.type,
         fragment.importance,
-        agentId
+        agentId,
+        fragment.agent_id,
+        fragment.workspace ?? null
       ],
       "write"
     ).catch(err => logWarn(`[FragmentWriter] archiveVersion failed: ${err.message}`));
@@ -274,20 +279,26 @@ export class FragmentWriter {
    * @param {string}      agentId  - 에이전트 ID
    * @param {string|null} keyId    - null: 마스터(전체 수정 가능), string: 소유 파편만 수정
    * @param {Object|null} existing - 미리 조회된 파편 (없으면 내부에서 조회)
+   * @param {Object}      [opts]
+   * @param {string}      [opts.amendedBy] - 이력에 기록할 승인/시스템 주체
    * @returns {Object|null} 갱신된 파편
    */
-  async update(id, updates, agentId = "default", keyId = null, existing = null) {
+  async update(id, updates, agentId = "default", keyId = null, existing = null, opts = {}) {
     if (!existing) {
       const lookup = await queryWithAgentVector(agentId,
         `SELECT id, content, topic, keywords, type, importance,
                 source, linked_to, agent_id, access_count,
                 accessed_at, created_at, ttl_tier, verified_at, is_anchor, key_id,
-                resolution_status, outcome, phase
+                resolution_status, outcome, phase, workspace
          FROM ${SCHEMA}.fragments WHERE id = $1`,
         [id]
       );
       existing = lookup.rows[0] || null;
       if (!existing) return null;
+    }
+
+    if (typeof existing.agent_id !== "string" || existing.agent_id.length === 0) {
+      throw new Error("Fragment agent scope is required for version history");
     }
 
     /** API 키 소유권 검사 */
@@ -313,8 +324,8 @@ export class FragmentWriter {
       await client.query(
         `INSERT INTO ${SCHEMA}.fragment_versions
                   (fragment_id, content, topic, keywords, type, importance, amended_by,
-                   resolution_status, outcome, phase)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+                   resolution_status, outcome, phase, agent_id, workspace)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
         [
           existing.id,
           existing.content,
@@ -322,10 +333,12 @@ export class FragmentWriter {
           existing.keywords,
           existing.type,
           existing.importance,
-          agentId,
+          opts.amendedBy ?? agentId,
           existing.resolution_status ?? null,
           existing.outcome ?? null,
-          existing.phase ?? null
+          existing.phase ?? null,
+          existing.agent_id,
+          existing.workspace ?? null
         ]
       );
 
@@ -464,6 +477,12 @@ export class FragmentWriter {
     if (updates.affect !== undefined) {
       setClauses.push(`affect = $${paramIdx}`);
       params.push(sanitizeAffect(updates.affect));
+      paramIdx++;
+    }
+
+    if (updates.agent_id !== undefined) {
+      setClauses.push(`agent_id = $${paramIdx}`);
+      params.push(updates.agent_id);
       paramIdx++;
     }
 

--- a/lib/memory/write/FragmentWriter.js
+++ b/lib/memory/write/FragmentWriter.js
@@ -13,9 +13,10 @@ import { MEMORY_CONFIG }                         from "../../../config/memory.js
 import { computeContentHash }                    from "../../tools/embedding.js";
 import { logWarn }                               from "../../logger.js";
 import { recordTenantIsolationBlocked }          from "../../metrics.js";
-import { keyScopeGroup, keyScopeScalar }          from "../keyScope.js";
+import { keyScopeClause, keyScopeGroup, keyScopeScalar } from "../keyScope.js";
 import { SCHEMA } from "../schema.js";
 import { workspaceCondition } from "../read/WorkspaceScope.js";
+import { agentScopeCondition, resolveAgentScope } from "../read/AgentScope.js";
 
 /**
  * 허용되는 정서 태그 값 집합.
@@ -285,13 +286,16 @@ export class FragmentWriter {
    */
   async update(id, updates, agentId = "default", keyId = null, existing = null, opts = {}) {
     if (!existing) {
+      const lookupParams = [id, agentId || "default"];
+      const lookupKeyClause = keyScopeScalar(lookupParams, "key_id", keyId);
       const lookup = await queryWithAgentVector(agentId,
         `SELECT id, content, topic, keywords, type, importance,
                 source, linked_to, agent_id, access_count,
                 accessed_at, created_at, ttl_tier, verified_at, is_anchor, key_id,
                 resolution_status, outcome, phase, workspace
-         FROM ${SCHEMA}.fragments WHERE id = $1`,
-        [id]
+         FROM ${SCHEMA}.fragments WHERE id = $1
+           AND (agent_id = $2 OR agent_id = 'default')${lookupKeyClause}`,
+        lookupParams
       );
       existing = lookup.rows[0] || null;
       if (!existing) return null;
@@ -318,6 +322,29 @@ export class FragmentWriter {
       await client.query("BEGIN");
       /** SET LOCAL은 파라미터 바인딩 미지원 — safeAgent는 [^a-zA-Z0-9_\-]로 정제됨 */
       await client.query(`SET LOCAL app.current_agent_id = '${safeAgent}'`);
+
+      // Every amendment locks before archiving. A waiter must archive the scope
+      // committed by an earlier normalization, never its stale preflight row.
+      const lockedResult = await client.query(
+        `SELECT * FROM ${SCHEMA}.fragments WHERE id = $1 FOR UPDATE`, [id]
+      );
+      const current = lockedResult.rows[0];
+      if (!current || (keyId && current.key_id !== keyId)
+        || (current.agent_id !== existing.agent_id && current.agent_id !== "default")) {
+        await client.query("ROLLBACK");
+        return null;
+      }
+      if (opts.normalizeVersionAgentToDefault === true
+        && (current.agent_id !== existing.agent_id
+          || current.key_id !== existing.key_id
+          || (current.workspace ?? null) !== (existing.workspace ?? null)
+          || current.is_anchor !== existing.is_anchor)) {
+        throw new Error("Approved fragment scope changed before normalization");
+      }
+      if (typeof current.agent_id !== "string" || current.agent_id.length === 0) {
+        throw new Error("Fragment agent scope is required for version history");
+      }
+      existing = current;
 
       /** 수정 전 상태 아카이빙 (버전 관리).
        *  케이스 상태 3종은 migration-038로 추가됐으며, UPDATE와 동일 트랜잭션에서 기록한다. */
@@ -354,6 +381,20 @@ export class FragmentWriter {
       }
 
       const result = await this._runUpdate(client, id, diff);
+
+      // Explicit, approved scope normalization shares the archived history too.
+      // Ordinary amendments keep their historical scope snapshots immutable.
+      if (opts.normalizeVersionAgentToDefault === true) {
+        if (updates.agent_id !== "default" || existing.agent_id !== agentId || !result) {
+          throw new Error("Invalid fragment history agent normalization");
+        }
+        await client.query(
+          `UPDATE ${SCHEMA}.fragment_versions
+              SET agent_id = 'default'
+            WHERE fragment_id = $1`,
+          [id]
+        );
+      }
 
       await client.query("COMMIT");
       return result;
@@ -743,14 +784,25 @@ export class FragmentWriter {
    * @param {string}      id     - 파편 ID
    * @param {string}      caseId - 할당할 case_id (UUID)
    * @param {string|null} keyId  - null: 마스터(전체 수정), string: 소유 파편만 수정
+   * @param {Object}      opts   - 선택 시 사용한 agent/key-group/workspace 재검증 범위
    * @returns {Promise<boolean>} 업데이트 성공 여부
    */
-  async updateCaseId(id, caseId, keyId = null) {
-    const params = [id, caseId];
-    const keyFilter = keyScopeScalar(params, "key_id", keyId).trimStart();
-    const result = await queryWithAgentVector("system",
+  async updateCaseId(id, caseId, keyId = null, opts = {}) {
+    const agentScope = resolveAgentScope(opts);
+    const params = [id, caseId, agentScope.agentId];
+    const keyFilter = keyScopeClause(params, "key_id", {
+      keyId, groupKeyIds: opts.groupKeyIds
+    });
+    const workspaceFilter = workspaceCondition(params, {
+      workspace: opts.workspace ?? null,
+      allWorkspaces: false
+    }, "workspace");
+    const result = await queryWithAgentVector(agentScope.agentId,
       `UPDATE ${SCHEMA}.fragments SET case_id = $2
-       WHERE id = $1 AND valid_to IS NULL ${keyFilter}`,
+       WHERE id = $1 AND valid_to IS NULL
+         AND ${agentScopeCondition("$3", agentScope)}
+         ${keyFilter}
+         AND ${workspaceFilter}`,
       params,
       "write"
     );

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -10,6 +10,12 @@ import prometheus        from "prom-client";
 /** 레지스트리 */
 export const register    = new prometheus.Registry();
 
+export const legacyUnboundAgentScopeTotal = new prometheus.Counter({
+  name: "mcp_legacy_unbound_agent_scope_total",
+  help: "Requests using the temporary unbound agent identity compatibility path",
+  registers: [register]
+});
+
 /** 기본 메트릭 활성화 (CPU, 메모리 등) — 단위 테스트 환경에서 MEMENTO_METRICS_DEFAULT=off 로 비활성화 */
 if (process.env.MEMENTO_METRICS_DEFAULT !== "off") {
   prometheus.collectDefaultMetrics({

--- a/lib/openapi.js
+++ b/lib/openapi.js
@@ -10,6 +10,7 @@
  */
 
 import { checkPermission }          from "./rbac.js";
+import { TOOL_REGISTRY }            from "./tool-registry.js";
 import { ADMIN_BASE }               from "./admin/admin-auth.js";
 import {
   rememberDefinition,
@@ -55,9 +56,11 @@ const ALL_TOOL_DEFINITIONS = [
 ];
 
 /** permissions 배열 기준으로 호출 가능한 도구만 추출 */
-function getAvailableTools(permissions) {
-  if (!permissions) return ALL_TOOL_DEFINITIONS;
-  return ALL_TOOL_DEFINITIONS.filter(def => checkPermission(permissions, def.name).allowed);
+function getAvailableTools(permissions, isMaster) {
+  return ALL_TOOL_DEFINITIONS.filter(def =>
+    checkPermission(permissions, def.name, isMaster).allowed &&
+    (isMaster === true || TOOL_REGISTRY.get(def.name)?.meta?.requiresMaster !== true)
+  );
 }
 
 /** ───────────────── 공통 스키마 ───────────────── */
@@ -758,7 +761,7 @@ function buildAdminPaths() {
  * @returns {object} OpenAPI 3.1.0 spec
  */
 export function buildSpec(isMaster, permissions) {
-  const availableTools = getAvailableTools(isMaster ? null : permissions);
+  const availableTools = getAvailableTools(isMaster ? null : permissions, isMaster);
 
   const description = isMaster
     ? "전체 API — master key"

--- a/lib/rbac.js
+++ b/lib/rbac.js
@@ -38,7 +38,7 @@ export const TOOL_PERMISSIONS = {
  * @param {string} toolName
  * @returns {{ allowed: boolean, required?: string, reason?: string }}
  */
-export function checkPermission(permissions, toolName) {
+export function checkPermission(permissions, toolName, isMaster = false) {
   const required = TOOL_PERMISSIONS[toolName];
   /**
    * default-deny. TOOL_PERMISSIONS에 등재되지 않은 도구는 마스터 키(permissions=null)
@@ -46,7 +46,8 @@ export function checkPermission(permissions, toolName) {
    * 갱신해야 한다.
    */
   if (!required) return { allowed: false, reason: "unknown_tool" };
-  if (!permissions) return { allowed: true };
+  if (isMaster === true) return { allowed: true };
+  if (!Array.isArray(permissions)) return { allowed: false, required, reason: "invalid_permissions" };
   if (permissions.includes(required)) return { allowed: true };
   if (permissions.includes("admin")) return { allowed: true };
   return { allowed: false, required };

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -7,7 +7,7 @@
  */
 
 import crypto            from "crypto";
-import { SESSION_TTL_MS, REDIS_ENABLED, CACHE_SESSION_TTL, SSE_HEARTBEAT_INTERVAL_MS, SSE_MAX_HEARTBEAT_FAILURES, IDLE_REFLECT_HOURS, SUPPORTED_PROTOCOL_VERSIONS } from "./config.js";
+import { SESSION_TTL_MS, REDIS_ENABLED, REDIS_SESSION_FAIL_CLOSED, CACHE_SESSION_TTL, SSE_HEARTBEAT_INTERVAL_MS, SSE_MAX_HEARTBEAT_FAILURES, IDLE_REFLECT_HOURS, SUPPORTED_PROTOCOL_VERSIONS } from "./config.js";
 import { MEMORY_CONFIG } from "../config/memory.js";
 import {
   saveSession as saveSessionToRedis,
@@ -15,7 +15,7 @@ import {
   deleteSession as deleteSessionFromRedis
 } from "./redis.js";
 import { autoReflect } from "./memory/processors/AutoReflect.js";
-import { logInfo } from "./logger.js";
+import { logInfo, logWarn } from "./logger.js";
 import { recordSessionIdleReflect, recordProtocolVersionReanchored } from "./metrics.js";
 
 /** Streamable HTTP 세션 저장소 */
@@ -148,7 +148,16 @@ export async function createStreamableSessionWithId(sessionId, authenticated = f
   streamableSessions.set(sessionId, session);
 
   if (REDIS_ENABLED) {
-    await saveSessionToRedis(sessionId, sessionData, CACHE_SESSION_TTL);
+    const saved = await saveSessionToRedis(sessionId, sessionData, CACHE_SESSION_TTL);
+    if (saved !== true && REDIS_SESSION_FAIL_CLOSED) {
+      await session.close({ preserveRedis: true });
+      const err = new Error("Session persistence failed");
+      err.statusCode = 503;
+      throw err;
+    }
+    if (saved !== true) {
+      logWarn("[Session] Redis persistence failed; continuing with in-memory session");
+    }
   }
 
   return sessionId;
@@ -520,10 +529,12 @@ export async function closeLegacySseSession(sessionId, { _preserveRedis = false 
  * - 기존 세션이 존재하지 않거나 만료됐으면 즉시 에러를 반환해 고아 세션 방지.
  *
  * @param {string} oldSessionId
- * @param {{ reason?: string }} [opts]
+ * @param {{ reason?: string, requesterIdentity?: {keyId: string|null, isMaster: boolean, groupKeyIds?: string[]|null, permissions?: string[]|null}, trustedLocal?: boolean }} [opts]
  * @returns {Promise<{ oldSessionId: string, newSessionId: string, expiresAt: number, keyId: string|null, workspace: string|null }>}
  */
-export async function rotateSession(oldSessionId, { reason = "explicit_rotate" } = {}) {
+export async function rotateSession(oldSessionId, {
+  reason = "explicit_rotate", requesterIdentity = null, trustedLocal = false
+} = {}) {
   /** 기존 세션 존재 및 유효성 확인 (validateStreamableSession은 TTL 갱신 부작용이 있으므로 직접 조회) */
   let existing = streamableSessions.get(oldSessionId);
 
@@ -540,6 +551,18 @@ export async function rotateSession(oldSessionId, { reason = "explicit_rotate" }
     throw err;
   }
 
+  if (trustedLocal !== true) {
+    const sameIdentity = requesterIdentity
+      && (requesterIdentity.keyId ?? null) === (existing.keyId ?? null)
+      && (requesterIdentity.isMaster === true) === (existing.isMaster === true)
+      && (requesterIdentity.isMaster === true || requesterIdentity.keyId != null);
+    if (!sameIdentity) {
+      const err = new Error("Session identity mismatch");
+      err.statusCode = 403;
+      throw err;
+    }
+  }
+
   const now = Date.now();
   if (now > existing.expiresAt) {
     /** 만료된 세션 — 정리 후 에러 반환 */
@@ -550,13 +573,15 @@ export async function rotateSession(oldSessionId, { reason = "explicit_rotate" }
   }
 
   /** 이관할 컨텍스트 스냅샷 (close 전에 캡처) */
-  const keyId            = existing.keyId            ?? null;
-  const groupKeyIds      = existing.groupKeyIds      ?? null;
-  const permissions      = existing.permissions      ?? null;
+  const freshIdentity    = trustedLocal === true ? existing : requesterIdentity;
+  const keyId            = freshIdentity.keyId ?? null;
+  /** 권한은 현재 credential로 갱신하되 요청별 세션 컨텍스트는 그대로 승계한다. */
+  const groupKeyIds      = freshIdentity.groupKeyIds ?? null;
+  const permissions      = freshIdentity.permissions ?? null;
   const defaultWorkspace = existing.defaultWorkspace ?? null;
-  const isMaster         = existing.isMaster === true;
   const mode             = existing.mode             ?? null;
   const authenticated    = existing.authenticated    ?? false;
+  const isMaster         = freshIdentity.isMaster === true;
 
   /** 신규 세션 발급 (동일 컨텍스트 이관) */
   const newSessionId = crypto.randomUUID();
@@ -572,25 +597,29 @@ export async function rotateSession(oldSessionId, { reason = "explicit_rotate" }
     isMaster
   );
 
-  /** 기존 세션 종료 — 신규 세션 등록 완료 후 진행 (부분 실패 시 신규 세션은 유효) */
-  try {
-    /** autoReflect를 건너뛰고 직접 close: rotate는 세션 전환이므로 reflect 불필요 */
-    const oldSession = streamableSessions.get(oldSessionId);
-    if (oldSession) {
-      await oldSession.close({ preserveRedis: false });
-    } else if (REDIS_ENABLED) {
-      await deleteSessionFromRedis(oldSessionId);
+  /** Redis 경계에서는 old 삭제 성공 후에만 local old를 닫는다. */
+  const oldSession = streamableSessions.get(oldSessionId);
+  if (REDIS_ENABLED) {
+    const deletedOld = await deleteSessionFromRedis(oldSessionId);
+    if (deletedOld !== true) {
+      const newSession = streamableSessions.get(newSessionId);
+      await newSession?.close({ preserveRedis: true });
+      await deleteSessionFromRedis(newSessionId).catch(() => false);
+      const err = new Error("Session rotation persistence failed");
+      err.statusCode = 503;
+      throw err;
     }
-  } catch {
-    /** 기존 세션 정리 실패는 무시 — 신규 세션이 이미 유효하므로 진행 */
+    await oldSession?.close({ preserveRedis: true });
+  } else {
+    await oldSession?.close({ preserveRedis: true });
   }
 
   const newSession = streamableSessions.get(newSessionId);
   const expiresAt  = newSession ? newSession.expiresAt : now + SESSION_TTL_MS;
 
-  logInfo(`[Session] Rotated: ${oldSessionId.slice(0, 8)}... → ${newSessionId.slice(0, 8)}... reason=${reason}`);
+  logInfo(`[Session] Rotated: ${oldSessionId.slice(0, 8)}... → ${newSessionId.slice(0, 8)}...`);
 
-  return { oldSessionId, newSessionId, expiresAt, keyId, workspace: defaultWorkspace };
+  return { oldSessionId, newSessionId, expiresAt, keyId, workspace: defaultWorkspace, mode, reason };
 }
 
 /**

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -37,6 +37,7 @@ export const legacySseSessions  = new Map();
  * @param {string|null} negotiatedVersion 자동복구 경로에서 즉시 재앵커링할 프로토콜 버전
  *                                        (계약 R2). 일반 신규 세션(initialize 전)은
  *                                        협상 전이므로 null을 유지한다.
+ * @param {boolean}     isMaster          인증 계층이 확정한 명시적 master 여부
  */
 export async function createStreamableSessionWithId(sessionId, authenticated = false, keyId = null, groupKeyIds = null, permissions = null, defaultWorkspace = null, mode = null, negotiatedVersion = null, isMaster = false) {
   let sseResponse         = null;
@@ -46,11 +47,11 @@ export async function createStreamableSessionWithId(sessionId, authenticated = f
   const sessionData       = {
     sessionId,
     authenticated,
+    isMaster           : isMaster === true,
     keyId              : keyId ?? null,
     groupKeyIds        : groupKeyIds ?? null,
     permissions        : permissions ?? null,
     defaultWorkspace   : defaultWorkspace ?? null,
-    isMaster           : isMaster === true,
     mode               : mode ?? null,
     createdAt          : now,
     expiresAt          : now + SESSION_TTL_MS,

--- a/lib/tool-registry.js
+++ b/lib/tool-registry.js
@@ -141,9 +141,9 @@ export const TOOL_REGISTRY = new Map([
     handler: tool_memoryStats,
     log:     () => "Memory stats retrieved",
     meta: {
-      capabilities:   ["analytics:read"],
+      capabilities:   ["analytics:read", "admin"],
       riskLevel:      "safe",
-      requiresMaster: false,
+      requiresMaster: true,
       beta:           false,
       idempotent:     true
     }
@@ -216,7 +216,7 @@ export const TOOL_REGISTRY = new Map([
   }],
   ["session_rotate", {
     handler: tool_sessionRotate,
-    log:     (args) => `Session rotate: reason=${args.reason || "user_request"}`,
+    log:     () => "Session rotated",
     meta: {
       capabilities:   ["session:write"],
       riskLevel:      "caution",
@@ -231,7 +231,7 @@ export const TOOL_REGISTRY = new Map([
     meta: {
       capabilities:   ["admin"],
       riskLevel:      "safe",
-      requiresMaster: false,
+      requiresMaster: true,
       beta:           false,
       idempotent:     true
     }

--- a/lib/tools/index.js
+++ b/lib/tools/index.js
@@ -85,7 +85,7 @@ import { checkUpdateDefinition, applyUpdateDefinition }         from "./update-t
 /**
  * 도구 정의 목록 (tools/list 응답용)
  */
-export function getToolsDefinition(keyId) {
+export function getToolsDefinition(_keyId, isMaster = false) {
   const base = [
     rememberDefinition,
     recallDefinition,
@@ -96,8 +96,6 @@ export function getToolsDefinition(keyId) {
     amendDefinition,
     reflectDefinition,
     toolFeedbackDefinition,
-    memoryStatsDefinition,
-    memoryConsolidateDefinition,
     graphExploreDefinition,
     fragmentHistoryDefinition,
     getSkillGuideDefinition,
@@ -106,8 +104,11 @@ export function getToolsDefinition(keyId) {
     sessionRotateDefinition,
     batchStatusDefinition
   ];
-  if (keyId === null) {
-    base.push(checkUpdateDefinition, applyUpdateDefinition);
+  if (isMaster === true) {
+    base.push(
+      memoryStatsDefinition, memoryConsolidateDefinition,
+      checkUpdateDefinition, applyUpdateDefinition
+    );
   }
   return base;
 }

--- a/lib/tools/memory-schemas.js
+++ b/lib/tools/memory-schemas.js
@@ -20,14 +20,16 @@ const COMMON_PARAMS = {
   /** 6곳 공유: recall, forget, link, amend, context, graphExplore */
   agentId: {
     type       : "string",
+    maxLength  : 128,
     description: "에이전트 ID",
-    examples   : ["agent-claude-code"]
+    examples   : ["default"]
   },
   /** 2곳 공유: remember, batchRemember */
   agentIdRls: {
     type       : "string",
+    maxLength  : 128,
     description: "에이전트 ID (RLS 격리용)",
-    examples   : ["agent-claude-code"]
+    examples   : ["default"]
   }
 };
 
@@ -414,7 +416,7 @@ export const recallDefinition = {
       },
       includePeerAgents: {
         type       : "boolean",
-        description: "true 시 같은 API 키/workspace 스코프 내 다른 agentId의 파편도 검색에 포함. 멀티에이전트 협업에서 상대 에이전트의 기억을 조회할 때 사용. 기본 false(현행 agent 격리 유지). 테넌트(키)·workspace 경계는 완화되지 않는다.",
+        description: "master key 전용. true 시 key/workspace 스코프 내 다른 agentId의 파편도 관리·감사 목적으로 포함한다. 일반 API key 요청은 권한 오류. 기본 false이며 key/workspace 경계는 완화하지 않는다.",
         examples   : [false, true]
       },
       includeKeyName: {
@@ -949,6 +951,11 @@ export const contextDefinition = {
         examples   : ["session-2026-04-20-001"]
       },
       agentId: COMMON_PARAMS.agentId,
+      includePeerAgents: {
+        type       : "boolean",
+        description: "master key 전용. true이면 key/workspace 경계 안의 모든 agent 기억을 관리·감사 목적으로 포함한다. 일반 API key 요청은 권한 오류를 반환한다.",
+        examples   : [false, true]
+      },
       workspace: {
         type       : "string",
         description: "워크스페이스 필터. 지정 시 해당 workspace 파편 + 전역(NULL) 파편만 반환. " +
@@ -1053,7 +1060,7 @@ export const toolFeedbackDefinition = {
 
 export const memoryStatsDefinition = {
   name       : "memory_stats",
-  description: "파편 기억 시스템 통계 조회. 전체 파편 수, TTL 분포, 유형별 통계, " +
+  description: "master key 전용 파편 기억 시스템 통계 조회. 전체 파편 수, TTL 분포, 유형별 통계, " +
                  "워크스페이스별 파편 분포, 링크 수, 최근 활동을 반환한다. " +
                  "할당량 소진 여부와 파편 분포 파악에 사용한다.",
   inputSchema: {
@@ -1097,7 +1104,16 @@ export const graphExploreDefinition = {
         description: "시작 파편 ID (error 파편 권장). recall로 에러 파편 ID를 먼저 조회 후 사용한다.",
         examples   : ["frag-error-001", "frag-abc123"]
       },
-      agentId: COMMON_PARAMS.agentId
+      agentId: COMMON_PARAMS.agentId,
+      includePeerAgents: {
+        type       : "boolean",
+        description: "master key 전용. true 시 key/workspace 경계 안의 모든 agent RCA 노드를 포함한다.",
+        examples   : [false, true]
+      },
+      workspace: {
+        type       : "string",
+        description: "RCA 시작·이웃 파편에 함께 적용할 workspace 범위"
+      }
     },
     required: ["startId"]
   }
@@ -1119,8 +1135,12 @@ export const fragmentHistoryDefinition = {
       agentId: COMMON_PARAMS.agentId,
       includePeerAgents: {
         type       : "boolean",
-        description: "true 시 같은 API 키 스코프 내 다른 agentId의 파편 이력도 조회한다. 테넌트(키) 경계는 완화되지 않는다. 기본 false.",
+        description: "master key 전용. true 시 같은 key/workspace 스코프의 다른 agentId 이력도 조회한다. 일반 API key 요청은 권한 오류. 기본 false.",
         examples   : [false, true]
+      },
+      workspace: {
+        type       : "string",
+        description: "현재 파편, 버전, superseded chain에 함께 적용할 workspace 범위"
       }
     },
     required: ["id"]
@@ -1197,6 +1217,11 @@ export const reconstructHistoryDefinition = {
         type       : "string",
         description: "워크스페이스 필터. 지정 시 해당 workspace + 전역(NULL) 파편만 대상.",
         examples   : ["memento-mcp"]
+      },
+      agentId: COMMON_PARAMS.agentId,
+      includePeerAgents: {
+        type       : "boolean",
+        description: "master key 전용. true 시 key/workspace 경계 내 모든 agent history를 포함한다."
       }
     }
   }
@@ -1280,6 +1305,11 @@ export const searchTracesDefinition = {
         type       : "string",
         description: "워크스페이스 필터. 지정 시 해당 workspace + 전역(NULL) 파편만 대상.",
         examples   : ["memento-mcp"]
+      },
+      agentId: COMMON_PARAMS.agentId,
+      includePeerAgents: {
+        type       : "boolean",
+        description: "master key 전용. true 시 key/workspace 경계 내 모든 agent trace를 포함한다."
       }
     }
   }

--- a/lib/tools/memory-schemas.js
+++ b/lib/tools/memory-schemas.js
@@ -1112,7 +1112,12 @@ export const graphExploreDefinition = {
       },
       workspace: {
         type       : "string",
-        description: "RCA 시작·이웃 파편에 함께 적용할 workspace 범위"
+        description: "RCA 시작·이웃 파편에 함께 적용할 workspace 범위. 생략 시 key 기본 workspace, 없으면 전역(NULL)만 조회한다."
+      },
+      allWorkspaces: {
+        type       : "boolean",
+        description: "master key 전용. true 시 모든 workspace에서 RCA 시작·이웃 파편을 조회한다. agent/key 범위는 유지한다. 기본 false.",
+        examples   : [false, true]
       }
     },
     required: ["startId"]
@@ -1140,7 +1145,12 @@ export const fragmentHistoryDefinition = {
       },
       workspace: {
         type       : "string",
-        description: "현재 파편, 버전, superseded chain에 함께 적용할 workspace 범위"
+        description: "현재 파편, 버전, superseded chain에 함께 적용할 workspace 범위. 생략 시 key 기본 workspace, 없으면 전역(NULL)만 조회한다."
+      },
+      allWorkspaces: {
+        type       : "boolean",
+        description: "master key 전용. true 시 모든 workspace에서 현재 파편, 버전, superseded chain을 조회한다. agent/key 범위는 유지한다. 기본 false.",
+        examples   : [false, true]
       }
     },
     required: ["id"]
@@ -1217,6 +1227,11 @@ export const reconstructHistoryDefinition = {
         type       : "string",
         description: "워크스페이스 필터. 지정 시 해당 workspace + 전역(NULL) 파편만 대상.",
         examples   : ["memento-mcp"]
+      },
+      allWorkspaces: {
+        type       : "boolean",
+        description: "master 전용 전체 workspace 조회. true이면 timeline, case event, evidence, 인과 링크의 workspace 필터를 제거한다.",
+        examples   : [false, true]
       },
       agentId: COMMON_PARAMS.agentId,
       includePeerAgents: {
@@ -1305,6 +1320,11 @@ export const searchTracesDefinition = {
         type       : "string",
         description: "워크스페이스 필터. 지정 시 해당 workspace + 전역(NULL) 파편만 대상.",
         examples   : ["memento-mcp"]
+      },
+      allWorkspaces: {
+        type       : "boolean",
+        description: "master 전용 전체 workspace 조회. true이면 trace의 workspace 필터를 제거한다.",
+        examples   : [false, true]
       },
       agentId: COMMON_PARAMS.agentId,
       includePeerAgents: {

--- a/lib/tools/memory.js
+++ b/lib/tools/memory.js
@@ -1031,8 +1031,7 @@ export async function tool_getSkillGuide(args) {
   try {
     /** Mode preset override: 섹션 지정이 없을 때 override 우선 반환 */
     const mode     = args?._mode   ?? null;
-    const keyId    = args?._keyId  ?? null;
-    const override = getSkillGuideOverride(mode, keyId === null);
+    const override = getSkillGuideOverride(mode, args?._isMaster === true);
     if (override && !args?.section) {
       return { success: true, mode, content: override };
     }

--- a/lib/tools/memory.js
+++ b/lib/tools/memory.js
@@ -36,6 +36,7 @@ import { computeConfidence } from "../memory/consolidate/UtilityBaseline.js";
 import { fetchLinkedFragments } from "../memory/read/LinkedFragmentLoader.js";
 import { stitchFragment, applyStitchBudget } from "../memory/read/TemporalContextStitcher.js";
 import { fetchCausalLinks, fetchSessionNeighbors } from "../memory/read/StitchSourceLoader.js";
+import { assertMasterPeerScope, agentScopeCondition, resolveAgentScope } from "../memory/read/AgentScope.js";
 import { rotateSession, currentSegmentId } from "../sessions.js";
 import { logSessionRotate }     from "../session-audit.js";
 import { serverTimeMeta }       from "./serverTime.js";
@@ -256,6 +257,7 @@ export async function tool_batchRemember(args, { onProgress = null } = {}) {
 export async function tool_recall(args) {
   const mgr = MemoryManager.getInstance();
   try {
+    const agentScope = assertMasterPeerScope(args);
     assertAllWorkspacesAuthorized(args);
     const sessionId = await normalizeRecallParams(args);
 
@@ -268,13 +270,17 @@ export async function tool_recall(args) {
 
     /** 1-hop 링크 파편 조회 (Task 4-2) */
     const fragmentIds = result.fragments.map(f => f.id);
-    const linkedMap   = await fetchLinkedFragments(fragmentIds, {
-      keyId: args._keyId ?? null,
-      groupKeyIds: args._groupKeyIds,
+    const linkedScope = {
+      agentId          : agentScope.agentId,
+      ...(agentScope._isMaster === true ? { _isMaster: true } : {}),
+      includePeerAgents: agentScope.includePeerAgents,
+      keyId            : args._keyId ?? null,
+      groupKeyIds      : args._groupKeyIds,
       ...workspaceScope,
       ...(args.includeSuperseded === true ? { includeSuperseded: true } : {}),
-      ...(args.isAnchor !== undefined ? { isAnchor: args.isAnchor } : {})
-    }).catch((err) => {
+      ...(args.isAnchor != null ? { isAnchor: args.isAnchor } : {})
+    };
+    const linkedMap   = await fetchLinkedFragments(fragmentIds, linkedScope).catch((err) => {
       logWarn("fetchLinkedFragments failed", { error: err.message, count: fragmentIds.length });
       return new Map();
     });
@@ -292,13 +298,9 @@ export async function tool_recall(args) {
         sessionIds.map(sid => mgr.store.searchBySource(
           `session:${sid}`,
           agentId,
-          keyId,
+          args._groupKeyIds ?? keyId,
           5,
-          {
-            ...workspaceScope,
-            ...(args.includeSuperseded === true ? { includeSuperseded: true } : {}),
-            ...(args.isAnchor !== undefined ? { isAnchor: args.isAnchor } : {})
-          }
+          linkedScope
         ))
       );
       const sessionMap = new Map(
@@ -326,13 +328,7 @@ export async function tool_recall(args) {
        *  있는 파편이 대부분 걸러져 기능이 사실상 발화하지 않는다.
        *  예산 비율을 넘으면 축약한다. 이 절삭이 없으면 스티칭이 tokenBudget을
        *  잠식해 앵커 파편이 응답에서 밀려난다. */
-      const stitchScope = {
-        keyId: args._keyId ?? null,
-        groupKeyIds: args._groupKeyIds,
-        ...workspaceScope,
-        ...(args.includeSuperseded === true ? { includeSuperseded: true } : {}),
-        ...(args.isAnchor !== undefined ? { isAnchor: args.isAnchor } : {})
-      };
+      const stitchScope = linkedScope;
       const [causalMap, neighborMap] = await Promise.all([
         fetchCausalLinks(result.fragments.map(f => f.id), stitchScope).catch((err) => {
           logWarn("fetchCausalLinks failed", { error: err.message });
@@ -367,13 +363,15 @@ export async function tool_recall(args) {
     const contradictionPending = result.caseMode
       ? false
       : await hasPendingContradictions(
-          (result.fragments ?? []).map(f => f.id).filter(Boolean),
-          {
-            keyId: args._keyId ?? null,
-            groupKeyIds: args._groupKeyIds,
-            ...workspaceScope
-          }
-        );
+        (result.fragments ?? []).map(f => f.id).filter(Boolean), linkedScope
+      );
+
+    await logAudit("recall", {
+      success          : true,
+      agentScope       : agentScope.auditLabel,
+      ...(agentScope._isMaster === true ? { _isMaster: true } : {}),
+      includePeerAgents: agentScope.includePeerAgents
+    });
 
     return buildRecallResponse(result, { args, linkedMap, contradictionPending });
   } catch (err) {
@@ -420,10 +418,10 @@ async function hasPendingContradictions(fragmentIds, scope = {}) {
   try {
     const pool = getPrimaryPool();
     if (!pool) return false;
-    const params = [fragmentIds];
+    const agentScope = resolveAgentScope(scope);
+    const params = [fragmentIds, agentScope.agentId];
     const keyClause = keyScopeClause(params, "o.key_id", {
-      keyId: scope.keyId ?? null,
-      groupKeyIds: scope.groupKeyIds
+      keyId: scope.keyId ?? null, groupKeyIds: scope.groupKeyIds
     });
     const workspaceFilter = workspaceCondition(params, scope, "o.workspace");
     const workspaceClause = workspaceFilter ? ` AND ${workspaceFilter}` : "";
@@ -435,7 +433,9 @@ async function hasPendingContradictions(fragmentIds, scope = {}) {
              ON o.id = CASE WHEN l.from_id = ANY($1) THEN l.to_id ELSE l.from_id END
           WHERE l.relation_type = 'contradicts'
             AND (l.from_id = ANY($1) OR l.to_id = ANY($1))
-            AND o.valid_to IS NULL${keyClause}${workspaceClause}
+            AND o.valid_to IS NULL
+            AND ${agentScopeCondition("$2", agentScope, "o.agent_id")}
+            ${keyClause}${workspaceClause}
        ) AS pending`,
       params
     );
@@ -662,6 +662,11 @@ async function withIdempotency(tool, args, run) {
 }
 
 export async function tool_amend(args) {
+  try {
+    assertMasterPeerScope(args);
+  } catch (err) {
+    return { success: false, error: err.message };
+  }
   const mgr = MemoryManager.getInstance();
   return withIdempotency("amend", args, () => withAudit("amend", args, async (a, sessionId) => {
     const result = await mgr.amend(a);
@@ -732,6 +737,7 @@ export async function tool_context(args) {
   const sessionId = await resolveSegmentedSessionId(args);
   try {
     assertAllWorkspacesAuthorized(args);
+    const agentScope = assertMasterPeerScope(args);
     const result = await mgr.context(args);
     SessionActivityTracker.record(sessionId, { tool: "context" }).catch(() => {});
     /** 응답 메타는 `_meta` 블록만 제공한다. */
@@ -742,6 +748,12 @@ export async function tool_context(args) {
       _anchorSelection,
       ...restResult
     } = result;
+    await logAudit("context", {
+      success          : true,
+      agentScope       : agentScope.auditLabel,
+      ...(agentScope._isMaster === true ? { _isMaster: true } : {}),
+      includePeerAgents: agentScope.includePeerAgents
+    });
     return {
       success: true,
       ...restResult,
@@ -900,13 +912,15 @@ export async function tool_memoryConsolidate(args, { onProgress = null } = {}) {
  * 시작 fragment 로부터 그래프를 N-hop 탐색해 인접 노드·링크를 반환한다.
  *
  * @param {Object} args - `{ startId, depth?, relationTypes?, limit?,
- *   includeContent?, workspace? }`.
+ *   includeContent?, workspace?, allWorkspaces? }`.
  * @returns {Promise<Object>} `{ success, nodes, edges, error? }`.
  */
 export async function tool_graphExplore(args) {
   delete args._sessionId;
   const mgr = MemoryManager.getInstance();
   try {
+    assertAllWorkspacesAuthorized(args);
+    assertMasterPeerScope(args);
     const result = await mgr.graphExplore(args);
     if (result.error) {
       return { success: false, ...result };
@@ -920,13 +934,15 @@ export async function tool_graphExplore(args) {
 /**
  * 단일 fragment 의 amend 이력·access trace·소속 case 이벤트를 시간순으로 반환한다.
  *
- * @param {Object} args - `{ id, limit?, includeAccessLog?, workspace? }`.
+ * @param {Object} args - `{ id, limit?, includeAccessLog?, workspace?, allWorkspaces? }`.
  * @returns {Promise<Object>} `{ success, history, error? }`.
  */
 export async function tool_fragmentHistory(args) {
   delete args._sessionId;
   const mgr = MemoryManager.getInstance();
   try {
+    assertAllWorkspacesAuthorized(args);
+    assertMasterPeerScope(args);
     const result = await mgr.fragmentHistory(args);
     if (result.error) {
       return { success: false, ...result };

--- a/lib/tools/memory.js
+++ b/lib/tools/memory.js
@@ -48,6 +48,7 @@ import {
   workspaceCondition
 } from "../memory/read/WorkspaceScope.js";
 import { keyScopeClause } from "../memory/keyScope.js";
+import { validateApiKeyById } from "../admin/ApiKeyStore.js";
 
 /** 시간·인과 스티칭 대상 상한. 상위 몇 건에만 붙여 응답 토큰을 통제한다. */
 const STITCH_MAX_TARGETS = 3;
@@ -1090,7 +1091,25 @@ export async function tool_sessionRotate(args) {
   }
 
   try {
-    const rotated = await rotateSession(sessionId, { reason });
+    let requesterIdentity;
+    if (args._isMaster === true) {
+      requesterIdentity = { keyId: null, isMaster: true };
+    } else if (keyId != null) {
+      const fresh = await validateApiKeyById(keyId);
+      if (!fresh.valid) return { success: false, error: "Session identity is no longer valid" };
+      requesterIdentity = {
+        keyId: fresh.keyId,
+        isMaster: false,
+        groupKeyIds: fresh.groupKeyIds ?? null,
+        permissions: fresh.permissions ?? null
+      };
+    } else {
+      return { success: false, error: "Session identity cannot be rotated" };
+    }
+    const rotated = await rotateSession(sessionId, {
+      reason,
+      requesterIdentity
+    });
 
     /** 감사 로그 기록 — 실패해도 rotate 결과에 영향 없음 */
     logSessionRotate({

--- a/lib/tools/reconstruct.js
+++ b/lib/tools/reconstruct.js
@@ -16,6 +16,8 @@ import { getPrimaryPool }   from "./db.js";
 import { logAudit }         from "../utils.js";
 import { keyScopeClause }   from "../memory/keyScope.js";
 import { SCHEMA } from "../memory/schema.js";
+import { assertMasterPeerScope, resolveAgentScope, agentScopeCondition } from "../memory/read/AgentScope.js";
+import { resolveWorkspaceScope, workspaceCondition } from "../memory/read/WorkspaceScope.js";
 
 export {
   reconstructHistoryDefinition,
@@ -44,7 +46,8 @@ function escapeLike(str) {
 export async function tool_reconstructHistory(args) {
   const keyId       = args._keyId             ?? null;
   const groupKeyIds = args._groupKeyIds        ?? (keyId != null ? [keyId] : []);
-  const workspace   = args.workspace           ?? args._defaultWorkspace ?? null;
+  const agentScope  = assertMasterPeerScope(args);
+  const workspaceScope = resolveWorkspaceScope(args);
   delete args._sessionId;
 
   if (!args.caseId && !args.entity) {
@@ -62,7 +65,10 @@ export async function tool_reconstructHistory(args) {
       limit       : args.limit     ?? 100,
       keyId,
       groupKeyIds,
-      workspace
+      ...workspaceScope,
+      agentId: agentScope.agentId,
+      ...(agentScope._isMaster === true ? { _isMaster: true } : {}),
+      includePeerAgents: agentScope.includePeerAgents
     });
 
     await logAudit("reconstruct_history", {
@@ -112,7 +118,8 @@ export async function tool_reconstructHistory(args) {
 export async function tool_searchTraces(args) {
   const keyId       = args._keyId             ?? null;
   const groupKeyIds = args._groupKeyIds        ?? (keyId != null ? [keyId] : []);
-  const workspace   = args.workspace           ?? args._defaultWorkspace ?? null;
+  const agentScope  = assertMasterPeerScope(args);
+  const workspaceScope = resolveWorkspaceScope(args);
   delete args._sessionId;
 
   const limit = Math.min(args.limit ?? 20, 100);
@@ -128,7 +135,10 @@ export async function tool_searchTraces(args) {
       limit,
       keyId,
       groupKeyIds,
-      workspace
+      ...workspaceScope,
+      agentId: agentScope.agentId,
+      ...(agentScope._isMaster === true ? { _isMaster: true } : {}),
+      includePeerAgents: agentScope.includePeerAgents
     });
 
     return {
@@ -146,11 +156,17 @@ export async function tool_searchTraces(args) {
  *
  * @private
  */
-async function _queryFragmentTraces({ event_type, entity_key, keyword, case_id, session_id, time_range, limit, keyId, groupKeyIds, workspace }) {
+async function _queryFragmentTraces({
+  event_type, entity_key, keyword, case_id, session_id, time_range, limit,
+  keyId, groupKeyIds, workspace, allWorkspaces, agentId, includePeerAgents, _isMaster
+}) {
   const pool   = getPrimaryPool();
   const params = [];
+  const agentScope = resolveAgentScope({ agentId, includePeerAgents, _isMaster });
+  params.push(agentScope.agentId);
+  const agentIdx = params.length;
 
-  /** $1: case_id */
+  /** case_id */
   params.push(case_id ?? null);
   const caseIdx = params.length;
 
@@ -182,8 +198,9 @@ async function _queryFragmentTraces({ event_type, entity_key, keyword, case_id, 
   const keyFilter = keyScopeClause(params, "f.key_id", { keyId, groupKeyIds });
 
   /** workspace 격리 */
-  params.push(workspace ?? null);
-  const wsIdx = params.length;
+  const workspaceFilter = workspaceCondition(
+    params, { workspace, allWorkspaces }, "f.workspace"
+  );
 
   /** limit */
   params.push(limit);
@@ -195,6 +212,7 @@ async function _queryFragmentTraces({ event_type, entity_key, keyword, case_id, 
            'fragment' AS source
       FROM ${SCHEMA}.fragments f
      WHERE ($${caseIdx}::text  IS NULL OR f.case_id    = $${caseIdx})
+       AND ${agentScopeCondition(`$${agentIdx}`, agentScope, "f.agent_id")}
        AND ($${sessIdx}::text  IS NULL OR f.session_id = $${sessIdx} OR f.session_id LIKE $${sessFamilyIdx})
        AND ($${kwIdx}::text    IS NULL OR f.content    ILIKE $${kwIdx})
        AND ($${entityIdx}::text IS NULL OR f.topic     ILIKE $${entityIdx})
@@ -202,7 +220,7 @@ async function _queryFragmentTraces({ event_type, entity_key, keyword, case_id, 
        AND ($${fromIdx}::timestamptz IS NULL OR f.created_at >= $${fromIdx})
        AND ($${toIdx}::timestamptz   IS NULL OR f.created_at <= $${toIdx})
        ${keyFilter}
-       AND ($${wsIdx}::text IS NULL OR f.workspace = $${wsIdx} OR f.workspace IS NULL)
+       AND ${workspaceFilter || "TRUE"}
        AND f.valid_to IS NULL
      ORDER BY f.created_at DESC
      LIMIT $${limitIdx}`;

--- a/lib/tools/resources.js
+++ b/lib/tools/resources.js
@@ -6,6 +6,9 @@ import { MEMORY_CONFIG } from "../../config/memory.js";
 import { getPrimaryPool } from "./db.js";
 import { SessionActivityTracker } from "../memory/processors/SessionActivityTracker.js";
 import { SCHEMA } from "../memory/schema.js";
+import { keyScopeClause } from "../memory/keyScope.js";
+import { agentScopeCondition, resolveAgentScope } from "../memory/read/AgentScope.js";
+import { resolveWorkspaceScope, workspaceCondition } from "../memory/read/WorkspaceScope.js";
 
 export const RESOURCES = [
   {
@@ -34,6 +37,22 @@ export const RESOURCES = [
   }
 ];
 
+function buildFragmentScope(params) {
+  const agentScope = resolveAgentScope(params);
+  const queryParams = [agentScope.agentId];
+  const conditions = [agentScopeCondition("$1", agentScope, "f.agent_id")];
+  const keyClause = keyScopeClause(queryParams, "f.key_id", {
+    keyId: params._keyId ?? null,
+    groupKeyIds: params._groupKeyIds
+  });
+  if (keyClause) conditions.push(keyClause.trim().replace(/^AND\s+/, ""));
+  const workspaceScope = resolveWorkspaceScope(params);
+  const workspaceClause = workspaceCondition(queryParams, workspaceScope, "f.workspace");
+  if (workspaceClause) conditions.push(workspaceClause);
+  conditions.push("f.valid_to IS NULL");
+  return { queryParams, where: conditions.join(" AND ") };
+}
+
 /**
  * 리소스 내용 읽기
  */
@@ -42,35 +61,18 @@ export async function readResource(uri, params = {}) {
 
   switch (uri) {
     case "memory://stats": {
-      const keyId       = params._keyId ?? null;
-      const groupKeyIds = params._groupKeyIds ?? (keyId ? [keyId] : null);
-      const keyIds      = groupKeyIds ?? (keyId ? [keyId] : null);
-
-      let stats;
-      if (keyIds) {
-        stats = await pool.query(`
+      const scope = buildFragmentScope(params);
+      const stats = await pool.query(`
           SELECT
-            type,
-            ttl_tier,
+            f.type,
+            f.ttl_tier,
             COUNT(*) as count,
-            AVG(importance) as avg_importance,
-            AVG(utility_score) as avg_utility
-          FROM ${SCHEMA}.fragments
-          WHERE key_id = ANY($1)
-          GROUP BY type, ttl_tier
-        `, [keyIds]);
-      } else {
-        stats = await pool.query(`
-          SELECT
-            type,
-            ttl_tier,
-            COUNT(*) as count,
-            AVG(importance) as avg_importance,
-            AVG(utility_score) as avg_utility
-          FROM ${SCHEMA}.fragments
-          GROUP BY type, ttl_tier
-        `);
-      }
+            AVG(f.importance) as avg_importance,
+            AVG(f.utility_score) as avg_utility
+          FROM ${SCHEMA}.fragments f
+          WHERE ${scope.where}
+          GROUP BY f.type, f.ttl_tier
+        `, scope.queryParams);
       return {
         contents: [
           {
@@ -83,25 +85,13 @@ export async function readResource(uri, params = {}) {
     }
 
     case "memory://topics": {
-      const keyId       = params._keyId ?? null;
-      const groupKeyIds = params._groupKeyIds ?? (keyId ? [keyId] : null);
-      const keyIds      = groupKeyIds ?? (keyId ? [keyId] : null);
-
-      let topics;
-      if (keyIds) {
-        topics = await pool.query(`
-          SELECT DISTINCT topic
-          FROM ${SCHEMA}.fragments
-          WHERE key_id = ANY($1)
-          ORDER BY topic ASC
-        `, [keyIds]);
-      } else {
-        topics = await pool.query(`
-          SELECT DISTINCT topic
-          FROM ${SCHEMA}.fragments
-          ORDER BY topic ASC
-        `);
-      }
+      const scope = buildFragmentScope(params);
+      const topics = await pool.query(`
+          SELECT DISTINCT f.topic
+          FROM ${SCHEMA}.fragments f
+          WHERE ${scope.where}
+          ORDER BY f.topic ASC
+        `, scope.queryParams);
       return {
         contents: [
           {

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -45,6 +45,15 @@ if (!DB_URL) {
   process.exit(1);
 }
 
+async function warnPendingAgentScopeSnapshots(client) {
+  // Load application configuration only after dotenv and DB setup are complete.
+  // Pass the existing migration connection: reporting must not open another pool.
+  const { warnPendingAgentScopeSnapshots: warnPending } = await import(
+    "../lib/memory/admin/AgentScopeBackfill.js"
+  );
+  await warnPending(client);
+}
+
 /**
  * 기반 스키마가 없으면 먼저 적용한다.
  *
@@ -147,6 +156,7 @@ async function migrate() {
 
     if (pending.length === 0) {
       console.log("All migrations already applied.");
+      await warnPendingAgentScopeSnapshots(client);
       return;
     }
 
@@ -181,6 +191,7 @@ async function migrate() {
     }
 
     console.log(`${pending.length} migration(s) applied successfully.`);
+    await warnPendingAgentScopeSnapshots(client);
   } finally {
     await client.query(`SELECT pg_advisory_unlock(${MIGRATE_LOCK_ID})`);
     console.log("Migration lock released");

--- a/server.js
+++ b/server.js
@@ -130,7 +130,7 @@ const server = http.createServer(async (req, res) => {
       res.end(JSON.stringify({ error: auth.error || "Unauthorized" }));
       return;
     }
-    const isMaster = auth.keyId == null;
+    const isMaster = auth.isMaster === true;
     const spec     = buildSpec(isMaster, isMaster ? null : (auth.permissions ?? []));
     res.statusCode = 200;
     res.setHeader("Content-Type", "application/json; charset=utf-8");

--- a/tests/e2e/agent-scope-rolling-migration.test.js
+++ b/tests/e2e/agent-scope-rolling-migration.test.js
@@ -1,0 +1,54 @@
+import "../integration/_cleanup.js";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { getPrimaryPool } from "../../lib/tools/db.js";
+
+test("migration-047 이후 구버전 fragment_versions INSERT가 계속 성공한다", async t => {
+  const pool = getPrimaryPool();
+  let client;
+  try {
+    client = await pool.connect();
+    await client.query("SELECT 1 FROM agent_memory.fragment_versions LIMIT 0");
+  } catch {
+    client?.release();
+    t.skip("PostgreSQL 또는 migration-047 schema를 사용할 수 없음");
+    return;
+  }
+
+  const id = `rolling-${crypto.randomUUID()}`;
+  try {
+    await client.query("BEGIN");
+    const columns = await client.query(
+      `SELECT column_name, is_nullable
+         FROM information_schema.columns
+        WHERE table_schema = 'agent_memory'
+          AND table_name = 'fragment_versions'
+          AND column_name IN ('agent_id', 'workspace')`
+    );
+    assert.equal(columns.rowCount, 2);
+    assert.equal(columns.rows.find(row => row.column_name === "agent_id")?.is_nullable, "YES");
+
+    await client.query(
+      `INSERT INTO agent_memory.fragments
+              (id, content, topic, type, content_hash, agent_id)
+       VALUES ($1, 'synthetic rolling fragment', 'synthetic', 'fact', $2, 'agent-a')`,
+      [id, crypto.randomUUID()]
+    );
+    /** 5.9 이하 writer 형태: 신규 snapshot 컬럼을 지정하지 않는다. */
+    await client.query(
+      `INSERT INTO agent_memory.fragment_versions
+              (fragment_id, content, topic, keywords, type, importance, amended_by)
+       VALUES ($1, 'synthetic old version', 'synthetic', '{}', 'fact', 0.5, 'agent-a')`,
+      [id]
+    );
+    const version = await client.query(
+      "SELECT agent_id, workspace FROM agent_memory.fragment_versions WHERE fragment_id = $1",
+      [id]
+    );
+    assert.deepEqual(version.rows[0], { agent_id: null, workspace: null });
+  } finally {
+    await client.query("ROLLBACK").catch(() => {});
+    client.release();
+  }
+});

--- a/tests/fixtures/cli-surface.snapshot.json
+++ b/tests/fixtures/cli-surface.snapshot.json
@@ -1,5 +1,6 @@
 {
   "registered": [
+    "anchor-scope",
     "backfill",
     "benchmark",
     "cleanup",
@@ -17,6 +18,7 @@
     "update"
   ],
   "localOnly": [
+    "anchor-scope",
     "backfill",
     "benchmark",
     "cleanup",
@@ -29,6 +31,7 @@
   ],
   "help": {
     "commands": [
+      "anchor-scope",
       "backfill",
       "benchmark",
       "cleanup",

--- a/tests/fixtures/tool-contract.snapshot.json
+++ b/tests/fixtures/tool-contract.snapshot.json
@@ -160,6 +160,9 @@
         "includeKeyName": {
           "type": "boolean"
         },
+        "includePeerAgents": {
+          "type": "boolean"
+        },
         "sessionId": {
           "type": "string"
         },
@@ -211,6 +214,9 @@
         },
         "includePeerAgents": {
           "type": "boolean"
+        },
+        "workspace": {
+          "type": "string"
         }
       },
       "required": [
@@ -230,7 +236,13 @@
         "agentId": {
           "type": "string"
         },
+        "includePeerAgents": {
+          "type": "boolean"
+        },
         "startId": {
+          "type": "string"
+        },
+        "workspace": {
           "type": "string"
         }
       },
@@ -270,18 +282,6 @@
         "fromId",
         "toId"
       ]
-    },
-    "memory_consolidate": {
-      "properties": {
-        "stream": {
-          "type": "boolean"
-        }
-      },
-      "required": []
-    },
-    "memory_stats": {
-      "properties": {},
-      "required": []
     },
     "recall": {
       "properties": {
@@ -424,11 +424,17 @@
     },
     "reconstruct_history": {
       "properties": {
+        "agentId": {
+          "type": "string"
+        },
         "caseId": {
           "type": "string"
         },
         "entity": {
           "type": "string"
+        },
+        "includePeerAgents": {
+          "type": "boolean"
         },
         "limit": {
           "type": "number"
@@ -666,6 +672,9 @@
     },
     "search_traces": {
       "properties": {
+        "agentId": {
+          "type": "string"
+        },
         "caseId": {
           "type": "string"
         },
@@ -683,6 +692,9 @@
         },
         "event_type": {
           "type": "string"
+        },
+        "includePeerAgents": {
+          "type": "boolean"
         },
         "keyword": {
           "type": "string"
@@ -965,6 +977,9 @@
         "includeKeyName": {
           "type": "boolean"
         },
+        "includePeerAgents": {
+          "type": "boolean"
+        },
         "sessionId": {
           "type": "string"
         },
@@ -1016,6 +1031,9 @@
         },
         "includePeerAgents": {
           "type": "boolean"
+        },
+        "workspace": {
+          "type": "string"
         }
       },
       "required": [
@@ -1035,7 +1053,13 @@
         "agentId": {
           "type": "string"
         },
+        "includePeerAgents": {
+          "type": "boolean"
+        },
         "startId": {
+          "type": "string"
+        },
+        "workspace": {
           "type": "string"
         }
       },
@@ -1229,11 +1253,17 @@
     },
     "reconstruct_history": {
       "properties": {
+        "agentId": {
+          "type": "string"
+        },
         "caseId": {
           "type": "string"
         },
         "entity": {
           "type": "string"
+        },
+        "includePeerAgents": {
+          "type": "boolean"
         },
         "limit": {
           "type": "number"
@@ -1471,6 +1501,9 @@
     },
     "search_traces": {
       "properties": {
+        "agentId": {
+          "type": "string"
+        },
         "caseId": {
           "type": "string"
         },
@@ -1488,6 +1521,9 @@
         },
         "event_type": {
           "type": "string"
+        },
+        "includePeerAgents": {
+          "type": "boolean"
         },
         "keyword": {
           "type": "string"

--- a/tests/fixtures/tool-contract.snapshot.json
+++ b/tests/fixtures/tool-contract.snapshot.json
@@ -3,7 +3,8 @@
     "amend": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "assertionStatus": {
           "type": "string",
@@ -15,7 +16,8 @@
           ]
         },
         "content": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 4000
         },
         "dryRun": {
           "type": "boolean"
@@ -24,7 +26,8 @@
           "type": "string"
         },
         "idempotencyKey": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "importance": {
           "type": "number"
@@ -77,7 +80,8 @@
     "batch_remember": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "async": {
           "type": "boolean"
@@ -88,10 +92,12 @@
             "type": "object",
             "properties": {
               "content": {
-                "type": "string"
+                "type": "string",
+                "maxLength": 4000
               },
               "idempotencyKey": {
-                "type": "string"
+                "type": "string",
+                "maxLength": 128
               },
               "importance": {
                 "type": "number"
@@ -152,7 +158,8 @@
     "context": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "allWorkspaces": {
           "type": "boolean"
@@ -187,7 +194,8 @@
     "forget": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "dryRun": {
           "type": "boolean"
@@ -207,7 +215,11 @@
     "fragment_history": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
+        },
+        "allWorkspaces": {
+          "type": "boolean"
         },
         "id": {
           "type": "string"
@@ -234,7 +246,11 @@
     "graph_explore": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
+        },
+        "allWorkspaces": {
+          "type": "boolean"
         },
         "includePeerAgents": {
           "type": "boolean"
@@ -253,7 +269,8 @@
     "link": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "dryRun": {
           "type": "boolean"
@@ -287,7 +304,8 @@
       "properties": {
         "affect": {},
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "allWorkspaces": {
           "type": "boolean"
@@ -425,7 +443,11 @@
     "reconstruct_history": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
+        },
+        "allWorkspaces": {
+          "type": "boolean"
         },
         "caseId": {
           "type": "string"
@@ -477,7 +499,8 @@
           }
         },
         "idempotencyKey": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "narrative_summary": {
           "type": "string"
@@ -565,7 +588,8 @@
           ]
         },
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "assertionStatus": {
           "type": "string",
@@ -580,7 +604,8 @@
           "type": "string"
         },
         "content": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 4000
         },
         "contextSummary": {
           "type": "string"
@@ -592,7 +617,8 @@
           "type": "string"
         },
         "idempotencyKey": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "importance": {
           "type": "number"
@@ -673,7 +699,11 @@
     "search_traces": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
+        },
+        "allWorkspaces": {
+          "type": "boolean"
         },
         "caseId": {
           "type": "string"
@@ -728,7 +758,8 @@
     "session_rotate": {
       "properties": {
         "reason": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 256
         }
       },
       "required": []
@@ -745,7 +776,8 @@
           }
         },
         "idempotencyKey": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "irrelevance_reason": {
           "type": "string",
@@ -794,7 +826,8 @@
     "amend": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "assertionStatus": {
           "type": "string",
@@ -806,7 +839,8 @@
           ]
         },
         "content": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 4000
         },
         "dryRun": {
           "type": "boolean"
@@ -815,7 +849,8 @@
           "type": "string"
         },
         "idempotencyKey": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "importance": {
           "type": "number"
@@ -886,7 +921,8 @@
     "batch_remember": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "async": {
           "type": "boolean"
@@ -897,10 +933,12 @@
             "type": "object",
             "properties": {
               "content": {
-                "type": "string"
+                "type": "string",
+                "maxLength": 4000
               },
               "idempotencyKey": {
-                "type": "string"
+                "type": "string",
+                "maxLength": 128
               },
               "importance": {
                 "type": "number"
@@ -969,7 +1007,8 @@
     "context": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "allWorkspaces": {
           "type": "boolean"
@@ -1004,7 +1043,8 @@
     "forget": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "dryRun": {
           "type": "boolean"
@@ -1024,7 +1064,11 @@
     "fragment_history": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
+        },
+        "allWorkspaces": {
+          "type": "boolean"
         },
         "id": {
           "type": "string"
@@ -1051,7 +1095,11 @@
     "graph_explore": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
+        },
+        "allWorkspaces": {
+          "type": "boolean"
         },
         "includePeerAgents": {
           "type": "boolean"
@@ -1070,7 +1118,8 @@
     "link": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "dryRun": {
           "type": "boolean"
@@ -1116,7 +1165,8 @@
       "properties": {
         "affect": {},
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "allWorkspaces": {
           "type": "boolean"
@@ -1254,7 +1304,11 @@
     "reconstruct_history": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
+        },
+        "allWorkspaces": {
+          "type": "boolean"
         },
         "caseId": {
           "type": "string"
@@ -1306,7 +1360,8 @@
           }
         },
         "idempotencyKey": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "narrative_summary": {
           "type": "string"
@@ -1394,7 +1449,8 @@
           ]
         },
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "assertionStatus": {
           "type": "string",
@@ -1409,7 +1465,8 @@
           "type": "string"
         },
         "content": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 4000
         },
         "contextSummary": {
           "type": "string"
@@ -1421,7 +1478,8 @@
           "type": "string"
         },
         "idempotencyKey": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "importance": {
           "type": "number"
@@ -1502,7 +1560,11 @@
     "search_traces": {
       "properties": {
         "agentId": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
+        },
+        "allWorkspaces": {
+          "type": "boolean"
         },
         "caseId": {
           "type": "string"
@@ -1557,7 +1619,8 @@
     "session_rotate": {
       "properties": {
         "reason": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 256
         }
       },
       "required": []
@@ -1574,7 +1637,8 @@
           }
         },
         "idempotencyKey": {
-          "type": "string"
+          "type": "string",
+          "maxLength": 128
         },
         "irrelevance_reason": {
           "type": "string",

--- a/tests/integration/session-rotate-flow.test.js
+++ b/tests/integration/session-rotate-flow.test.js
@@ -77,7 +77,10 @@ async function createSession(overrides = {}) {
     overrides.keyId         ?? null,
     null,
     null,
-    overrides.workspace     ?? null
+    overrides.workspace     ?? null,
+    null,
+    null,
+    overrides.isMaster      ?? true
   );
   return { sid, streamableSessions };
 }
@@ -214,7 +217,7 @@ describe("시나리오 3: CSRF Origin 거부", () => {
 /* ------------------------------------------------------------------ */
 describe("시나리오 4: rotate 후 새 sessionId로 세션 접근 가능", () => {
   it("rotate 후 반환된 newSessionId로 세션 유효성 검증 통과", async () => {
-    const { sid, streamableSessions } = await createSession({ authenticated: true, keyId: "k-test" });
+    const { sid, streamableSessions } = await createSession({ authenticated: true, keyId: null, isMaster: true });
 
     const { handleSessionRotate } = await import("../../lib/handlers/session-handler.js");
     const req = makeReq({ sessionId: sid });
@@ -227,9 +230,10 @@ describe("시나리오 4: rotate 후 새 sessionId로 세션 접근 가능", () 
     /** 신규 세션이 streamableSessions에 존재 */
     assert.ok(streamableSessions.has(newSessionId), "newSessionId가 sessions Map에 없음");
 
-    /** 신규 세션의 keyId가 이관됨 */
+    /** 신규 master 세션 identity가 이관됨 */
     const newSession = streamableSessions.get(newSessionId);
-    assert.strictEqual(newSession.keyId, "k-test", "keyId 이관 실패");
+    assert.strictEqual(newSession.keyId, null, "master keyId 이관 실패");
+    assert.strictEqual(newSession.isMaster, true, "master identity 이관 실패");
     assert.strictEqual(newSession.authenticated, true, "authenticated 이관 실패");
 
     /** 구 sessionId로 재 rotate 시 404 */
@@ -237,5 +241,17 @@ describe("시나리오 4: rotate 후 새 sessionId로 세션 접근 가능", () 
     const res2 = fakeRes();
     await handleSessionRotate(req2, res2);
     assert.strictEqual(res2.statusCode, 404, `구 sessionId가 아직 유효함: statusCode=${res2.statusCode}`);
+  });
+
+  it("master caller도 다른 tenant identity 세션은 회전하지 못한다", async () => {
+    const { sid, streamableSessions } = await createSession({
+      authenticated: true, keyId: "key-a", isMaster: false
+    });
+    const { handleSessionRotate } = await import("../../lib/handlers/session-handler.js");
+    const req = makeReq({ sessionId: sid });
+    const res = fakeRes();
+    await handleSessionRotate(req, res);
+    assert.strictEqual(res.statusCode, 403);
+    assert.equal(streamableSessions.has(sid), true);
   });
 });

--- a/tests/unit/agent-id-transport-validation.test.js
+++ b/tests/unit/agent-id-transport-validation.test.js
@@ -1,0 +1,56 @@
+import { describe, test, mock } from "node:test";
+import assert from "node:assert/strict";
+
+let resourceCalls = 0;
+mock.module("../../lib/tools/resources.js", {
+  exports: {
+    RESOURCES: [],
+    readResource: async () => {
+      resourceCalls++;
+      return { contents: [] };
+    }
+  }
+});
+
+const { dispatchJsonRpc } = await import("../../lib/jsonrpc.js");
+const { TOOL_REGISTRY } = await import("../../lib/tool-registry.js");
+const { rbacDeniedTotal } = await import("../../lib/metrics.js");
+
+const master = {
+  authenticated: true, keyId: null, groupKeyIds: null, permissions: null,
+  defaultWorkspace: null, mode: null, sessionId: "validation-session", isMaster: true
+};
+
+describe("agentId transport length validation", () => {
+  for (const method of ["tools/call", "resources/read"]) {
+    test(`${method}: accepts 128 and rejects 129 without handler or RBAC denial`, async () => {
+      const original = TOOL_REGISTRY.get("recall");
+      let toolCalls = 0;
+      TOOL_REGISTRY.set("recall", {
+        ...original, post: null, log: null,
+        handler: async () => { toolCalls++; return { content: [] }; }
+      });
+      const invoke = agentId => dispatchJsonRpc({
+        id: 1, method,
+        params: method === "tools/call"
+          ? { name: "recall", arguments: { agentId } }
+          : { uri: "memory://stats", agentId }
+      }, master);
+      try {
+        const accepted = await invoke("a".repeat(128));
+        assert.equal(accepted.kind, "ok");
+        const beforeTools = toolCalls;
+        const beforeResources = resourceCalls;
+        const beforeDenials = await rbacDeniedTotal.get();
+        const rejected = await invoke("a".repeat(129));
+        assert.equal(rejected.response.error.code, -32602);
+        assert.match(rejected.response.error.message, /agentId.*128/);
+        assert.equal(toolCalls, beforeTools);
+        assert.equal(resourceCalls, beforeResources);
+        assert.deepEqual(await rbacDeniedTotal.get(), beforeDenials);
+      } finally {
+        TOOL_REGISTRY.set("recall", original);
+      }
+    });
+  }
+});

--- a/tests/unit/agent-scope-backfill.test.js
+++ b/tests/unit/agent-scope-backfill.test.js
@@ -1,0 +1,205 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  backfillAgentScopeSnapshots,
+  assertBackfillComplete,
+  getAgentScopeBackfillStatus,
+  getPendingScopeSnapshotCounts,
+  hasAgentScopeSnapshotSchema,
+  warnPendingAgentScopeSnapshots
+} from "../../lib/memory/admin/AgentScopeBackfill.js";
+
+function schemaRows() {
+  return [
+    { table_name: "fragment_versions", column_name: "agent_id" },
+    { table_name: "fragment_versions", column_name: "workspace" },
+    { table_name: "case_events", column_name: "agent_id" },
+    { table_name: "case_events", column_name: "workspace" }
+  ];
+}
+
+describe("agent scope snapshot backfill", () => {
+  it("migration schema 네 컬럼을 모두 확인한다", async () => {
+    const complete = { query: async () => ({ rows: schemaRows() }) };
+    const partial = { query: async () => ({ rows: schemaRows().slice(0, 3) }) };
+    assert.equal(await hasAgentScopeSnapshotSchema(complete), true);
+    assert.equal(await hasAgentScopeSnapshotSchema(partial), false);
+  });
+
+  it("source 없는 이벤트와 삭제된 source 이벤트를 별도 COUNT로 노출한다", async () => {
+    let call = 0;
+    const pool = { query: async sql => {
+      call++;
+      if (call === 1) return { rows: schemaRows() };
+      if (/fragment_versions/.test(sql)) return { rows: [{ pending: 8, backfillable: 8 }] };
+      return { rows: [{ pending: 7, backfillable: 3, sourceMissing: 2, sourceDeleted: 2 }] };
+    } };
+    const status = await getAgentScopeBackfillStatus(pool);
+    assert.deepEqual(status.caseEvents, {
+      pending: 7, backfillable: 3, sourceMissing: 2, sourceDeleted: 2
+    });
+  });
+
+  it("신뢰 가능한 source가 있는 행만 짧은 배치로 반복 갱신한다", async () => {
+    const versionCounts = [2, 1, 1, 0];
+    const eventCounts = [2, 0];
+    const pool = { query: async sql => {
+      if (/information_schema/.test(sql)) return { rows: schemaRows() };
+      if (/SELECT COUNT/.test(sql)) return { rows: [{ pending: 0, backfillable: 0 }] };
+      if (/UPDATE agent_memory\.fragment_versions/.test(sql)) {
+        return { rowCount: versionCounts.shift() };
+      }
+      if (/UPDATE agent_memory\.case_events/.test(sql)) {
+        return { rowCount: eventCounts.shift() };
+      }
+      throw new Error(`unexpected query: ${sql}`);
+    } };
+    const result = await backfillAgentScopeSnapshots({ batchSize: 2 }, pool);
+    assert.deepEqual(result, { fragmentVersions: 4, caseEvents: 2 });
+    assert.deepEqual(versionCounts, []);
+    assert.deepEqual(eventCounts, []);
+  });
+
+  it("정규화 대상의 pending version/event snapshot을 모두 검사한다", async () => {
+    let call = 0;
+    const pool = { query: async (_sql, params) => {
+      call++;
+      if (call === 1) return { rows: schemaRows() };
+      assert.deepEqual(params, [["fragment-a", "fragment-b"]]);
+      return { rows: [{ fragmentVersions: 2, caseEvents: 3 }] };
+    } };
+    assert.deepEqual(
+      await getPendingScopeSnapshotCounts(["fragment-a", "fragment-b"], pool),
+      { fragmentVersions: 2, caseEvents: 3, total: 5 }
+    );
+  });
+
+  it("계속 가득 차는 version 배치를 제한하고 커밋된 진행 이후 재개한다", async () => {
+    let pending = 4;
+    let concurrentWriter = true;
+    let updateCalls = 0;
+    const pool = { query: async sql => {
+      if (/information_schema/.test(sql)) return { rows: schemaRows() };
+      if (/SELECT COUNT/.test(sql)) return { rows: [{ pending: 0, backfillable: 0 }] };
+      updateCalls++;
+      if (/UPDATE agent_memory\.fragment_versions/.test(sql)) {
+        const updated = Math.min(pending, 2);
+        pending -= updated;
+        if (concurrentWriter) pending += 2;
+        return { rowCount: updated };
+      }
+      return { rowCount: 0 };
+    } };
+
+    await assert.rejects(
+      backfillAgentScopeSnapshots({ batchSize: 2, maxBatches: 3 }, pool),
+      error => {
+        assert.equal(error.code, "SNAPSHOT_BACKFILL_LIMIT");
+        assert.deepEqual(error.progress, { fragmentVersions: 6, caseEvents: 0, batches: 3 });
+        assert.match(error.message, /committed progress: versions=6, events=0; rerun to resume/);
+        return true;
+      }
+    );
+    assert.equal(updateCalls, 3);
+    assert.equal(pending, 4);
+    concurrentWriter = false;
+    assert.deepEqual(await backfillAgentScopeSnapshots({ batchSize: 2 }, pool), {
+      fragmentVersions: 4, caseEvents: 0
+    });
+    assert.equal(pending, 0);
+  });
+
+  it("case event가 계속 유입되어도 두 테이블을 합친 배치 상한을 지킨다", async () => {
+    let updateCalls = 0;
+    const pool = { query: async sql => {
+      if (/information_schema/.test(sql)) return { rows: schemaRows() };
+      updateCalls++;
+      return { rowCount: /UPDATE agent_memory\.case_events/.test(sql) ? 2 : 0 };
+    } };
+    await assert.rejects(
+      backfillAgentScopeSnapshots({ batchSize: 2, maxBatches: 3 }, pool),
+      error => {
+        assert.deepEqual(error.progress, { fragmentVersions: 0, caseEvents: 4, batches: 3 });
+        return true;
+      }
+    );
+    assert.equal(updateCalls, 3);
+  });
+
+  it("마지막 허용 배치에서 완료하면 정상 반환한다", async () => {
+    const counts = [2, 0, 1, 0];
+    const pool = { query: async sql => {
+      if (/information_schema/.test(sql)) return { rows: schemaRows() };
+      if (/SELECT COUNT/.test(sql)) return { rows: [{ pending: 0, backfillable: 0 }] };
+      return { rowCount: counts.shift() };
+    } };
+    assert.deepEqual(
+      await backfillAgentScopeSnapshots({ batchSize: 2, maxBatches: 4 }, pool),
+      { fragmentVersions: 2, caseEvents: 1 }
+    );
+    assert.deepEqual(counts, []);
+  });
+
+  it("유한한 양의 정수가 아닌 배치 상한은 DB 접근 전에 거부한다", async () => {
+    const pool = { query: () => assert.fail("unexpected database access") };
+    for (const maxBatches of [0, -1, 1.5, Infinity, NaN, "3", true, Number.MAX_SAFE_INTEGER + 1]) {
+      await assert.rejects(
+        backfillAgentScopeSnapshots({ maxBatches }, pool), /maxBatches must be a positive safe integer/
+      );
+    }
+  });
+
+  it("backfill 뒤 신뢰 가능한 잔여 행이 있으면 성공 처리하지 않는다", () => {
+    assert.doesNotThrow(() => assertBackfillComplete({
+      fragmentVersions: { backfillable: 0 }, caseEvents: { backfillable: 0 }
+    }));
+    assert.throws(() => assertBackfillComplete({
+      fragmentVersions: { backfillable: 1 }, caseEvents: { backfillable: 2 }
+    }), /left 3 backfillable row/);
+  });
+
+  it("잠긴 행으로 zero batch가 나와도 직접 호출자는 미완료 상태를 받는다", async () => {
+    const pool = { query: async sql => {
+      if (/information_schema/.test(sql)) return { rows: schemaRows() };
+      if (/SELECT COUNT/.test(sql)) return { rows: [{ pending: 1, backfillable: 1 }] };
+      assert.match(sql, /SKIP LOCKED/);
+      return { rowCount: 0 };
+    } };
+    await assert.rejects(backfillAgentScopeSnapshots({}, pool), error => {
+      assert.equal(error.code, "SNAPSHOT_BACKFILL_INCOMPLETE");
+      assert.equal(error.status.fragmentVersions.pending, 1);
+      assert.deepEqual(error.progress, { fragmentVersions: 0, caseEvents: 0, batches: 2 });
+      return true;
+    });
+  });
+
+  it("복구할 source가 없는 snapshot은 구조화된 미완료 보고로 남긴다", () => {
+    const status = { migrationReady: true,
+      fragmentVersions: { pending: 0, backfillable: 0 },
+      caseEvents: { pending: 3, backfillable: 0, sourceMissing: 2, sourceDeleted: 1 } };
+    assert.throws(() => assertBackfillComplete(status), error => {
+      assert.equal(error.code, "SNAPSHOT_BACKFILL_INCOMPLETE");
+      assert.equal(error.status, status);
+      assert.match(error.message, /sourceMissing=2, sourceDeleted=1/);
+      return true;
+    });
+  });
+
+  it("migration 후 두 테이블의 pending 집계만 경고하고 데이터를 변경하지 않는다", async () => {
+    for (const table of ["fragment_versions", "case_events"]) {
+      const warnings = [];
+      const pool = { query: async sql => {
+        assert.match(sql.trim(), /^SELECT/);
+        if (/information_schema/.test(sql)) return { rows: schemaRows() };
+        return { rows: [{ pending: sql.includes(table) ? 2 : 0, backfillable: 0 }] };
+      } };
+      await warnPendingAgentScopeSnapshots(pool, text => warnings.push(text));
+      assert.equal(warnings.length, 1);
+      assert.match(warnings[0], /anchor-scope --backfill-snapshots/);
+    }
+    const warnings = [];
+    await warnPendingAgentScopeSnapshots({ query: async () => ({ rows: [] }) },
+      text => warnings.push(text));
+    assert.deepEqual(warnings, []);
+  });
+});

--- a/tests/unit/agent-scope-contract.test.js
+++ b/tests/unit/agent-scope-contract.test.js
@@ -1,0 +1,189 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+const captured = [];
+const warnings = [];
+mock.module("../../lib/logger.js", {
+  namedExports: { logWarn: message => warnings.push(message) }
+});
+const pool = {
+  query: async (sql, params) => {
+    captured.push({ sql, params });
+    return { rows: [] };
+  }
+};
+
+mock.module("../../lib/tools/db.js", {
+  namedExports: {
+    getPrimaryPool: () => pool,
+    queryWithAgentVector: async (agentId, sql, params) => {
+      captured.push({ agentId, sql, params });
+      return { rows: [] };
+    }
+  }
+});
+mock.module("../../lib/tools/embedding.js", {
+  namedExports: { vectorToSql: value => JSON.stringify(value) }
+});
+
+const {
+  resolveAgentScope,
+  isFragmentInAgentScope,
+  assertMasterPeerScope,
+  assertAuthenticatedAgentScope
+} = await import("../../lib/memory/read/AgentScope.js");
+const { FragmentReader } = await import("../../lib/memory/read/FragmentReader.js");
+const { fetchLinkedFragments } = await import("../../lib/memory/read/LinkedFragmentLoader.js");
+const { fetchCausalLinks, fetchSessionNeighbors } = await import("../../lib/memory/read/StitchSourceLoader.js");
+const { classifyAnchors } = await import("../../lib/memory/admin/AnchorScopeInventory.js");
+const { legacyUnboundAgentScopeTotal } = await import("../../lib/metrics.js");
+
+describe("effective agent scope", () => {
+  it("embedded peer 조회는 master trust가 없으면 I/O 전에 거부한다", async () => {
+    captured.length = 0;
+    assert.throws(() => resolveAgentScope({ includePeerAgents: true }), /master-key only/);
+    await assert.rejects(new FragmentReader().getById("fragment-a", "agent-a", null, [], {
+      includePeerAgents: true
+    }), /master-key only/);
+    assert.equal(captured.length, 0);
+    const trusted = resolveAgentScope({ includePeerAgents: true, _isMaster: true });
+    assert.equal(resolveAgentScope(trusted).includePeerAgents, true);
+  });
+
+  it("agentId는 서버에서도 128자 경계를 검증한다", () => {
+    assert.equal(resolveAgentScope({ agentId: "a".repeat(128) }).agentId.length, 128);
+    assert.throws(() => resolveAgentScope({ agentId: "a".repeat(129) }), { code: "INVALID_PARAMS" });
+  });
+
+  it("유예 경로를 실제 사용하는 non-master non-default 요청만 경고와 카운터를 남긴다", async () => {
+    const before = (await legacyUnboundAgentScopeTotal.get()).values[0].value;
+    warnings.length = 0;
+    assertAuthenticatedAgentScope({ agentId: "default" });
+    assertAuthenticatedAgentScope({ agentId: "private", _isMaster: true });
+    assert.throws(() => assertAuthenticatedAgentScope({ agentId: "private" }, { allowLegacyUnbound: false }));
+    assert.throws(() => assertAuthenticatedAgentScope({ agentId: "private", includePeerAgents: true }));
+    assert.equal(warnings.length, 0);
+    assert.equal((await legacyUnboundAgentScopeTotal.get()).values[0].value, before);
+    assertAuthenticatedAgentScope({ agentId: "private" });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE=false/);
+    assert.doesNotMatch(warnings[0], /private/);
+    assert.equal((await legacyUnboundAgentScopeTotal.get()).values[0].value, before + 1);
+  });
+  it("agentId 생략은 default-only이다", () => {
+    const scope = resolveAgentScope({});
+    assert.equal(scope.auditLabel, "default-only");
+    assert.deepEqual(scope.agentIds, ["default"]);
+    assert.equal(isFragmentInAgentScope({ agent_id: "default" }, scope), true);
+    assert.equal(isFragmentInAgentScope({ agent_id: "agent-a" }, scope), false);
+  });
+
+  it("specific agent는 own + default이고 metadata 누락은 fail-closed이다", () => {
+    const scope = resolveAgentScope({ agentId: "agent-a" });
+    assert.deepEqual(scope.agentIds, ["agent-a", "default"]);
+    assert.equal(isFragmentInAgentScope({ agent_id: "agent-a" }, scope), true);
+    assert.equal(isFragmentInAgentScope({ agent_id: "default" }, scope), true);
+    assert.equal(isFragmentInAgentScope({ agent_id: "agent-b" }, scope), false);
+    assert.equal(isFragmentInAgentScope({}, scope), false);
+  });
+
+  it("peer-agent 권한표는 master만 허용한다", () => {
+    assert.doesNotThrow(() => assertMasterPeerScope({ includePeerAgents: true, _isMaster: true }));
+    assert.throws(
+      () => assertMasterPeerScope({ includePeerAgents: true, _isMaster: false }),
+      /master-key only/
+    );
+    assert.throws(
+      () => assertMasterPeerScope({ includePeerAgents: true, _keyId: null }),
+      /master-key only/
+    );
+    assert.doesNotThrow(() => assertMasterPeerScope({ includePeerAgents: false, _isMaster: false }));
+  });
+
+  it("peer-agent도 agent metadata가 없는 cache row를 fail-closed한다", () => {
+    const scope = resolveAgentScope({ agentId: "agent-a", includePeerAgents: true, _isMaster: true });
+    assert.equal(isFragmentInAgentScope({ agent_id: "agent-b" }, scope), true);
+    assert.equal(isFragmentInAgentScope({ agent_id: "default" }, scope), true);
+    assert.equal(isFragmentInAgentScope({ agent_id: null }, scope), false);
+    assert.equal(isFragmentInAgentScope({}, scope), false);
+  });
+
+  it("legacy unbound agent 유예는 기본 허용이고 명시적 false는 거부한다", () => {
+    const params = { agentId: "agent-a", _isMaster: false };
+    assert.doesNotThrow(() => assertAuthenticatedAgentScope(params));
+    assert.throws(() => assertAuthenticatedAgentScope(params, { allowLegacyUnbound: false }), /not authorized/);
+    assert.doesNotThrow(() => assertAuthenticatedAgentScope(params, { allowLegacyUnbound: true }));
+  });
+
+  it("audit label은 줄바꿈과 구분자를 제거한다", () => {
+    const scope = resolveAgentScope({ agentId: "agent-a\nforged|record" });
+    assert.equal(scope.auditLabel, "specific+default");
+    assert.doesNotMatch(scope.auditLabel, /agent-a|[\r\n|;]/);
+  });
+});
+
+describe("source/linked/stitch hydration", () => {
+  it("source 조회는 agent + key-group + workspace를 동시에 적용한다", async () => {
+    captured.length = 0;
+    const reader = new FragmentReader();
+    await reader.searchBySource(
+      "learning_extraction", "agent-a", ["key-a", "key-b"], 5, "workspace-a"
+    );
+    const call = captured.at(-1);
+    assert.match(call.sql, /\(agent_id = \$2 OR agent_id = 'default'\)/);
+    assert.match(call.sql, /key_id = ANY\(\$3::text\[\]\)/);
+    assert.match(call.sql, /workspace = \$4/);
+  });
+
+  it("linked preview는 agent/key/workspace 범위를 적용한다", async () => {
+    captured.length = 0;
+    await fetchLinkedFragments(["fragment-a"], {
+      agentId: "agent-a", keyId: "key-a", groupKeyIds: ["key-a"], workspace: "workspace-a"
+    });
+    const call = captured.at(-1);
+    assert.match(call.sql, /f\.agent_id = \$2/);
+    assert.match(call.sql, /f\.key_id/);
+    assert.match(call.sql, /f\.workspace/);
+  });
+
+  it("causal/session hydration은 peer 모드에서도 key/workspace를 유지한다", async () => {
+    captured.length = 0;
+    const scope = {
+      agentId: "agent-a", includePeerAgents: true, _isMaster: true,
+      keyId: "key-a", groupKeyIds: ["key-a"], workspace: "workspace-a"
+    };
+    await fetchCausalLinks(["fragment-a"], scope);
+    await fetchSessionNeighbors([
+      { id: "fragment-a", session_id: "session-a", created_at: "2026-01-01T00:00:00Z" }
+    ], scope);
+    for (const call of captured) {
+      assert.match(call.sql, /peer-agent: no [a-z._]+ filter/);
+      assert.match(call.sql, /f\.agent_id IS NOT NULL/);
+      assert.match(call.sql, /f\.key_id/);
+      assert.match(call.sql, /f\.workspace/);
+    }
+  });
+});
+
+describe("anchor inventory classification", () => {
+  it("명시 승인 외에는 private/unconfirmed 상태를 보존한다", () => {
+    const rows = [
+      { id: "anchor-shared", agent_id: "agent-a" },
+      { id: "anchor-private", agent_id: "agent-a" },
+      { id: "anchor-unknown", agent_id: "agent-b" }
+    ];
+    const result = classifyAnchors(rows, {
+      shared: new Set(["anchor-shared"]), private: new Set(["anchor-private"])
+    });
+    assert.deepEqual(result.map(item => item.category), ["shared", "private", "unconfirmed"]);
+  });
+
+  it("같은 anchor의 shared/private 중복 분류를 거부한다", () => {
+    assert.throws(
+      () => classifyAnchors([{ id: "anchor-a", agent_id: "agent-a" }], {
+        shared: new Set(["anchor-a"]), private: new Set(["anchor-a"])
+      }),
+      /classification conflict/
+    );
+  });
+});

--- a/tests/unit/agent-scope-migration.test.js
+++ b/tests/unit/agent-scope-migration.test.js
@@ -1,0 +1,38 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const migration = readFileSync(path.join(
+  here, "../../lib/memory/migrations/migration-047-agent-scope-audit.sql"
+), "utf8");
+const schema = readFileSync(path.join(here, "../../lib/memory/memory-schema.sql"), "utf8");
+
+describe("migration-047 fragment version scope", () => {
+  it("nullable snapshot 컬럼만 추가하여 구버전 writer와 롤링 호환된다", () => {
+    assert.match(migration, /ALTER TABLE agent_memory\.fragment_versions[\s\S]*ADD COLUMN IF NOT EXISTS agent_id[\s\S]*ADD COLUMN IF NOT EXISTS workspace/);
+    assert.doesNotMatch(migration, /UPDATE agent_memory\.fragment_versions/);
+    assert.doesNotMatch(migration, /ALTER COLUMN agent_id SET NOT NULL/);
+  });
+
+  it("private history를 shared로 오분류할 DEFAULT를 두지 않고 workspace NULL은 허용한다", () => {
+    const ddl = migration.replace(/--.*$/gm, "");
+    const versions = schema.match(/CREATE TABLE IF NOT EXISTS agent_memory\.fragment_versions \([\s\S]*?\n\);/)?.[0] ?? "";
+    assert.doesNotMatch(ddl, /ALTER COLUMN agent_id SET DEFAULT/);
+    assert.doesNotMatch(ddl, /ALTER COLUMN workspace SET NOT NULL/);
+    assert.match(versions, /agent_id\s+TEXT/);
+    assert.doesNotMatch(versions, /agent_id[^\n]*NOT NULL/);
+    assert.doesNotMatch(versions, /agent_id[^\n]*DEFAULT/);
+  });
+
+  it("legacy case event 컬럼은 migration 소유이고 backfill은 별도 배치로 분리한다", () => {
+    assert.match(migration, /ALTER TABLE agent_memory\.case_events[\s\S]*ADD COLUMN IF NOT EXISTS agent_id[\s\S]*ADD COLUMN IF NOT EXISTS workspace/);
+    assert.doesNotMatch(migration, /UPDATE agent_memory\.case_events/);
+    const caseAlters = [...migration.matchAll(/ALTER TABLE agent_memory\.case_events[\s\S]*?;/g)]
+      .map(match => match[0]).join("\n");
+    assert.doesNotMatch(caseAlters, /ALTER COLUMN agent_id SET NOT NULL/);
+    assert.doesNotMatch(schema, /CREATE TABLE IF NOT EXISTS agent_memory\.case_events/);
+  });
+});

--- a/tests/unit/agent-scope-storage-paths.test.js
+++ b/tests/unit/agent-scope-storage-paths.test.js
@@ -1,0 +1,412 @@
+import { describe, it, mock, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+let calls = [];
+let responses = [];
+let primaryResponses = [];
+
+mock.module("../../lib/tools/db.js", {
+  namedExports: {
+    getPrimaryPool: () => ({
+      query: async (sql, params) => {
+        calls.push({ agentId: null, sql, params });
+        return primaryResponses.shift() ?? { rows: [] };
+      }
+    }),
+    queryWithAgentVector: async (agentId, sql, params) => {
+      calls.push({ agentId, sql, params });
+      return responses.shift() ?? { rows: [] };
+    },
+    withTransaction: async (_pool, fn) => fn({
+      query: async (sql, params) => {
+        calls.push({ agentId: "transaction", sql, params });
+        if (/COALESCE\(MAX\(sequence_no\)/.test(sql)) return { rows: [{ next_seq: 0 }] };
+        if (/SELECT agent_id, workspace/.test(sql)) {
+          return { rows: [{ agent_id: "agent-a", workspace: "workspace-a" }] };
+        }
+        if (/INSERT INTO agent_memory\.case_events/.test(sql)) {
+          return { rows: [{ event_id: "event-created", sequence_no: 0 }] };
+        }
+        return { rows: [] };
+      }
+    })
+  }
+});
+mock.module("../../lib/tools/embedding.js", {
+  namedExports: { vectorToSql: value => JSON.stringify(value), computeContentHash: value => value }
+});
+
+const { FragmentReader } = await import("../../lib/memory/read/FragmentReader.js");
+const { LinkStore } = await import("../../lib/memory/link/LinkStore.js");
+const { HistoryReconstructor } = await import("../../lib/memory/read/HistoryReconstructor.js");
+const { CaseEventStore } = await import("../../lib/memory/CaseEventStore.js");
+const { CaseRecall } = await import("../../lib/memory/read/CaseRecall.js");
+const { MemoryReflector } = await import("../../lib/memory/processors/MemoryReflector.js");
+const { FragmentWriter } = await import("../../lib/memory/write/FragmentWriter.js");
+
+beforeEach(() => {
+  calls = [];
+  responses = [];
+  primaryResponses = [];
+});
+
+describe("fragment point lookup workspace contract", () => {
+  it("opts 생략 내부 getById/getByIds는 named-workspace 처리용 무필터를 유지한다", async () => {
+    const reader = new FragmentReader();
+    await reader.getById("fragment-a", "agent-a", "key-a", ["key-a"]);
+    await reader.getByIds(["fragment-a"], "agent-a", "key-a", ["key-a"]);
+
+    assert.equal(calls.length, 2);
+    for (const call of calls) {
+      assert.doesNotMatch(call.sql, /(?:f\.)?workspace IS NULL/);
+      assert.doesNotMatch(call.sql, /(?:f\.)?workspace = \$/);
+    }
+  });
+
+  it("workspace:null을 명시한 scoped getById/getByIds는 global-only다", async () => {
+    const reader = new FragmentReader();
+    await reader.getById(
+      "fragment-global", "agent-a", "key-a", ["key-a"], { workspace: null }
+    );
+    await reader.getByIds(
+      ["fragment-global"], "agent-a", "key-a", ["key-a"], { workspace: null }
+    );
+
+    assert.equal(calls.length, 2);
+    assert.match(calls[0].sql, /workspace IS NULL/);
+    assert.match(calls[1].sql, /workspace IS NULL/);
+  });
+});
+
+describe("auto-case scope contract", () => {
+  it("case lookup은 agent own+default와 key group, named workspace+global을 결합한다", async () => {
+    const reader = new FragmentReader();
+    await reader.findCaseIdBySessionTopic(
+      "session-a", "topic-a", "key-a", ["key-a", "key-b"],
+      { agentId: "agent-a", workspace: "project-a" }
+    );
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].agentId, "agent-a");
+    assert.match(calls[0].sql, /\(agent_id = \$3 OR agent_id = 'default'\)/);
+    assert.match(calls[0].sql, /key_id = ANY/);
+    assert.match(calls[0].sql, /\(workspace = \$\d+ OR workspace IS NULL\)/);
+    assert.deepEqual(calls[0].params, [
+      "session-a", "topic-a", "agent-a", "key-a", ["key-a", "key-b"], "project-a"
+    ]);
+  });
+
+  it("error lookup과 case backfill은 null workspace를 global-only로 재검증한다", async () => {
+    const reader = new FragmentReader();
+    await reader.findErrorFragmentsBySessionTopic(
+      "session-a", "topic-a", null, [], { agentId: "agent-a", workspace: null }
+    );
+    await new FragmentWriter().updateCaseId(
+      "error-a", "case-a", null,
+      { agentId: "agent-a", groupKeyIds: [], workspace: null }
+    );
+
+    assert.equal(calls.length, 2);
+    assert.match(calls[0].sql, /\(agent_id = \$3 OR agent_id = 'default'\)/);
+    assert.match(calls[0].sql, /workspace IS NULL/);
+    assert.match(calls[1].sql, /\(agent_id = \$3 OR agent_id = 'default'\)/);
+    assert.match(calls[1].sql, /workspace IS NULL/);
+    assert.equal(calls[1].agentId, "agent-a");
+  });
+});
+
+describe("fragment_history scoped hydration", () => {
+  it("allWorkspaces는 current/version/chain의 workspace 제한만 해제한다", async () => {
+    responses = [
+      { rows: [{ id: "fragment-a", agent_id: "agent-a", workspace: "workspace-a" }] },
+      { rows: [{ fragment_id: "fragment-a", workspace: "workspace-b" }] },
+      { rows: [{ to_id: "fragment-b", workspace: "workspace-c" }] }
+    ];
+    const result = await new FragmentReader().getHistory(
+      "fragment-a", "agent-a", "key-a", ["key-a"], { workspace: null, allWorkspaces: true }
+    );
+    assert.equal(result.current.workspace, "workspace-a");
+    assert.equal(result.versions.length, 1);
+    assert.equal(result.superseded_by_chain.length, 1);
+    assert.equal(calls.length, 3);
+    for (const call of calls) {
+      assert.doesNotMatch(call.sql, /(?:f\.)?workspace (?:IS NULL|= \$)/);
+      assert.match(call.sql, /agent_id = \$2/);
+    }
+    assert.match(calls[0].sql, /key_id/);
+    assert.match(calls[2].sql, /f\.key_id/);
+  });
+
+  it("current, versions, chain에 agent/key/workspace 범위를 모두 적용한다", async () => {
+    responses = [
+      { rows: [{ id: "fragment-a", agent_id: "agent-a", workspace: "workspace-a" }] },
+      { rows: [{ fragment_id: "fragment-a", agent_id: "agent-a", workspace: "workspace-a" }] },
+      { rows: [] }
+    ];
+    const reader = new FragmentReader();
+    const result = await reader.getHistory(
+      "fragment-a", "agent-a", "key-a", ["key-a"], { workspace: "workspace-a" }
+    );
+
+    assert.equal(calls.length, 3);
+    assert.match(calls[0].sql, /agent_id = \$2/);
+    assert.match(calls[0].sql, /key_id/);
+    assert.match(calls[0].sql, /workspace/);
+    assert.match(calls[1].sql, /agent_id = \$2/);
+    assert.match(calls[1].sql, /workspace/);
+    assert.deepEqual(calls[1].params, ["fragment-a", "agent-a", "workspace-a"]);
+    assert.deepEqual(result.versions, [
+      { fragment_id: "fragment-a", agent_id: "agent-a", workspace: "workspace-a" }
+    ]);
+    assert.match(calls[2].sql, /f\.agent_id = \$2/);
+    assert.match(calls[2].sql, /f\.key_id/);
+    assert.match(calls[2].sql, /f\.workspace/);
+  });
+
+  it("current가 scope 밖이면 versions와 chain을 조회하지 않는다", async () => {
+    responses = [{ rows: [] }];
+    const result = await new FragmentReader().getHistory(
+      "fragment-b", "agent-a", "key-a", ["key-a"], { workspace: "workspace-a" }
+    );
+    assert.equal(calls.length, 1);
+    assert.deepEqual(result, { current: null, versions: [], superseded_by_chain: [] });
+  });
+
+  it("공개 경로가 명시한 null workspace는 current/version/chain을 전역으로 제한한다", async () => {
+    responses = [
+      { rows: [{ id: "fragment-global", agent_id: "default", workspace: null }] },
+      { rows: [] },
+      { rows: [] }
+    ];
+    await new FragmentReader().getHistory(
+      "fragment-global", "default", null, [], { workspace: null }
+    );
+    assert.equal(calls.length, 3);
+    assert.match(calls[0].sql, /workspace IS NULL/);
+    assert.match(calls[1].sql, /workspace IS NULL/);
+    assert.match(calls[2].sql, /f\.workspace IS NULL/);
+  });
+});
+
+describe("graph_explore RCA scope", () => {
+  it("allWorkspaces는 seed/target workspace 필터만 제거하고 agent/key를 유지한다", async () => {
+    responses = [{ rows: [{ id: "fragment-b", workspace: "workspace-b" }] }];
+    const result = await new LinkStore().getRCAChain(
+      "fragment-a", "agent-a", "key-a", ["key-a"], { workspace: null, allWorkspaces: true }
+    );
+    assert.equal(result.length, 1);
+    assert.doesNotMatch(calls[0].sql, /f2?\.workspace (?:IS NULL|= \$)/);
+    assert.match(calls[0].sql, /f\.agent_id = \$2/);
+    assert.match(calls[0].sql, /f2\.agent_id = \$2/);
+    assert.match(calls[0].sql, /f\.key_id/);
+    assert.match(calls[0].sql, /f2\.key_id/);
+  });
+
+  it("seed와 target 모두 agent/key/workspace 조건을 적용한다", async () => {
+    responses = [{ rows: [] }];
+    await new LinkStore().getRCAChain(
+      "fragment-a", "agent-a", "key-a", ["key-a"], { workspace: "workspace-a" }
+    );
+    const call = calls[0];
+    assert.equal(call.agentId, "agent-a");
+    assert.match(call.sql, /f\.agent_id = \$2/);
+    assert.match(call.sql, /f2\.agent_id = \$2/);
+    assert.match(call.sql, /f\.key_id/);
+    assert.match(call.sql, /f2\.key_id/);
+    assert.match(call.sql, /f\.workspace/);
+    assert.match(call.sql, /f2\.workspace/);
+  });
+
+  it("peer mode도 key/workspace 조건은 유지한다", async () => {
+    responses = [{ rows: [] }];
+    await new LinkStore().getRCAChain(
+      "fragment-a", "agent-a", "key-a", ["key-a"],
+      { workspace: "workspace-a", includePeerAgents: true, _isMaster: true }
+    );
+    assert.match(calls[0].sql, /peer-agent: no [a-z0-9._]+ filter/);
+    assert.match(calls[0].sql, /f2\.key_id/);
+    assert.match(calls[0].sql, /f2\.workspace/);
+  });
+
+  it("workspace 미지정 RCA는 seed와 target을 전역(NULL)으로 제한한다", async () => {
+    responses = [{ rows: [] }];
+    await new LinkStore().getRCAChain("fragment-a", "default", null, []);
+    assert.match(calls[0].sql, /f\.workspace IS NULL/);
+    assert.match(calls[0].sql, /f2\.workspace IS NULL/);
+  });
+});
+
+describe("reconstruct/search trace scope", () => {
+  it("reconstruct_history timeline에 agent/key/workspace 범위를 전파한다", async () => {
+    const reconstructor = new HistoryReconstructor({}, {}, null);
+    await reconstructor.reconstruct({
+      caseId: "case-a", agentId: "agent-a", keyId: "key-a",
+      groupKeyIds: ["key-a"], workspace: "workspace-a"
+    });
+    const timeline = calls[0];
+    assert.match(timeline.sql, /\(f\.agent_id = \$1 OR f\.agent_id = 'default'\)/);
+    assert.match(timeline.sql, /f\.key_id/);
+    assert.match(timeline.sql, /f\.workspace/);
+    assert.equal(timeline.params[0], "agent-a");
+  });
+
+  it("case events/evidence/DAG/links에 동일 scope를 끝까지 전파한다", async () => {
+    primaryResponses = [
+      { rows: [{ id: "fragment-a", agent_id: "agent-a", resolution_status: "open" }] },
+      { rows: [{ from_id: "fragment-a", to_id: "fragment-a", relation_type: "caused_by" }] }
+    ];
+    const seen = [];
+    const caseEventStore = {
+      getByCase: async (_caseId, opts) => {
+        seen.push(["case", opts]);
+        return [{ event_id: "event-a", event_type: "error_observed" }];
+      },
+      getEdgesByEvents: async (ids, keyId) => {
+        seen.push(["dag", { ids, keyId }]);
+        return [];
+      },
+      getEvidenceByEvent: async (_eventId, opts) => {
+        seen.push(["evidence", opts]);
+        return [];
+      }
+    };
+    await new HistoryReconstructor({}, {}, caseEventStore).reconstruct({
+      caseId: "case-a", agentId: "agent-a", keyId: "key-a",
+      groupKeyIds: ["key-a"], workspace: "workspace-a"
+    });
+    for (const [kind, scope] of seen.filter(([kind]) => kind !== "dag")) {
+      assert.equal(scope.agentId, "agent-a", kind);
+      assert.equal(scope.includePeerAgents, false, kind);
+      assert.equal(scope.keyId, "key-a", kind);
+      assert.equal(scope.workspace, "workspace-a", kind);
+      assert.equal(scope.allWorkspaces, false, kind);
+    }
+    assert.deepEqual(seen.find(([kind]) => kind === "dag")?.[1], {
+      ids: ["event-a"],
+      keyId: {
+        keyId: "key-a", groupKeyIds: ["key-a"], workspace: "workspace-a",
+        allWorkspaces: false, _isMaster: false,
+        agentId: "agent-a", includePeerAgents: false
+      }
+    });
+    const linkCall = calls.find(call => /FROM agent_memory\.fragment_links fl/.test(call.sql));
+    assert.match(linkCall.sql, /fl\.from_id = ANY\(\$1\)/);
+    assert.match(linkCall.sql, /fl\.to_id\s+= ANY\(\$1\)/);
+    assert.match(linkCall.sql, /\bOR\b/);
+    assert.match(linkCall.sql, /f_from\.agent_id/);
+    assert.match(linkCall.sql, /f_to\.agent_id/);
+    assert.match(linkCall.sql, /f_from\.key_id/);
+    assert.match(linkCall.sql, /f_to\.key_id/);
+    assert.match(linkCall.sql, /f_from\.workspace/);
+    assert.match(linkCall.sql, /f_to\.workspace/);
+  });
+
+  it("MemoryReflector facade가 master allWorkspaces를 reconstructor까지 보존한다", async () => {
+    primaryResponses = [{ rows: [] }];
+    const reflector = new MemoryReflector({
+      reflectProcessor: {}, store: { links: {} }, caseEventStore: null, consolidator: {}
+    });
+
+    await reflector.reconstructHistory({
+      caseId: "case-all", agentId: "default",
+      allWorkspaces: true, _isMaster: true
+    });
+
+    assert.equal(calls.length, 1);
+    assert.doesNotMatch(calls[0].sql, /workspace IS NULL|workspace = \$/);
+  });
+
+});
+
+describe("case event fragment scope matrix", () => {
+  it("append가 source fragment의 agent/workspace snapshot을 저장한다", async () => {
+    await new CaseEventStore().append({
+      case_id: "case-a",
+      event_type: "error_observed",
+      summary: "synthetic event",
+      source_fragment_id: "fragment-a",
+      key_id: "key-a"
+    });
+    const sourceRead = calls.find(call => /SELECT agent_id, workspace/.test(call.sql));
+    const insert = calls.find(call => /INSERT INTO agent_memory\.case_events/.test(call.sql));
+    assert.deepEqual(sourceRead.params, ["fragment-a", "key-a"]);
+    assert.match(insert.sql, /agent_id, workspace/);
+    assert.equal(insert.params.at(-2), "agent-a");
+    assert.equal(insert.params.at(-1), "workspace-a");
+  });
+
+  it("getByCase는 current fragment가 아니라 immutable event snapshot을 필터한다", async () => {
+    await new CaseEventStore().getByCase("case-a", {
+      agentId: "agent-a", keyId: "key-a", groupKeyIds: ["key-a"],
+      workspace: "workspace-a"
+    });
+    assert.match(calls[0].sql, /ce\.agent_id/);
+    assert.match(calls[0].sql, /ce\.key_id/);
+    assert.match(calls[0].sql, /ce\.workspace/);
+    assert.doesNotMatch(calls[0].sql, /JOIN\s+agent_memory\.fragments/);
+  });
+
+  it("workspace 미지정 event snapshot 조회는 전역(NULL)으로 제한한다", async () => {
+    await new CaseEventStore().getByCase("case-a", { agentId: "default" });
+    assert.match(calls[0].sql, /ce\.workspace IS NULL/);
+  });
+
+  for (const scope of [
+    { name: "default", opts: { agentId: "default" }, expected: /[a-z]+\.agent_id = \$\d+/ },
+    { name: "specific", opts: { agentId: "agent-a" }, expected: /\([a-z]+\.agent_id = \$\d+ OR [a-z]+\.agent_id = 'default'\)/ },
+    { name: "peer", opts: { agentId: "agent-a", includePeerAgents: true, _isMaster: true }, expected: /peer-agent: no [a-z._]+ filter/ }
+  ]) {
+    it(`${scope.name} 범위를 case event와 evidence SQL에 동일 적용한다`, async () => {
+      const store = new CaseEventStore();
+      const opts = {
+        ...scope.opts, keyId: "key-a", groupKeyIds: ["key-a"], workspace: "workspace-a"
+      };
+      await store.getByCase("case-a", opts);
+      await store.getEvidenceByEvent("event-a", opts);
+      for (const call of calls) {
+        assert.match(call.sql, scope.expected);
+        if (scope.name === "peer") {
+          assert.match(call.sql, /(?:ce|f)\.agent_id IS NOT NULL/);
+        }
+        assert.match(call.sql, /\.key_id/);
+        assert.match(call.sql, /\.workspace/);
+      }
+    });
+  }
+
+  it("DAG edge는 snapshot agent/workspace와 전체 group key를 양 끝점에 적용한다", async () => {
+    await new CaseEventStore().getEdgesByEvents(["event-a", "event-b"], {
+      agentId: "agent-a", keyId: "key-a", groupKeyIds: ["key-a", "key-b"],
+      workspace: "workspace-a"
+    });
+    assert.match(calls[0].sql, /ee\.from_event_id = ANY\(\$1::uuid\[\]\)/);
+    assert.match(calls[0].sql, /ee\.to_event_id\s+= ANY\(\$1::uuid\[\]\)/);
+    assert.match(calls[0].sql, /\bOR\b/);
+    assert.match(calls[0].sql, /ce_from\.agent_id/);
+    assert.match(calls[0].sql, /ce_to\.agent_id/);
+    assert.match(calls[0].sql, /ce_from\.workspace/);
+    assert.match(calls[0].sql, /ce_to\.workspace/);
+    assert.equal(
+      calls[0].params.filter(value => Array.isArray(value) && value.includes("key-b")).length,
+      2
+    );
+  });
+});
+
+describe("CaseRecall event snapshot scope", () => {
+  it("event summary를 current fragment JOIN 없이 ce snapshot으로 필터한다", async () => {
+    primaryResponses = [
+      { rows: [{ case_id: "case-a", resolution_status: "open", fragment_count: 1 }] },
+      { rows: [{ case_id: "case-a", event_type: "error_observed", summary: "synthetic" }] }
+    ];
+    await new CaseRecall().buildCaseTriples([{ case_id: "case-a" }], {
+      agentId: "agent-a", keyId: "key-a", groupKeyIds: ["key-a"],
+      workspace: "workspace-a"
+    });
+    const eventQuery = calls.find(call => /FROM agent_memory\.case_events ce/.test(call.sql));
+    assert.match(eventQuery.sql, /ce\.agent_id/);
+    assert.match(eventQuery.sql, /ce\.key_id/);
+    assert.match(eventQuery.sql, /ce\.workspace/);
+    assert.doesNotMatch(eventQuery.sql, /JOIN\s+agent_memory\.fragments/);
+  });
+});

--- a/tests/unit/anchor-agent-normalization.test.js
+++ b/tests/unit/anchor-agent-normalization.test.js
@@ -1,0 +1,369 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+const queries = [];
+let failVersionNormalization = false;
+let lockedFragment = null;
+const client = {
+  query: async (sql, params = []) => {
+    queries.push({ sql, params });
+    if (/FOR UPDATE/.test(sql)) return { rows: lockedFragment ? [lockedFragment] : [] };
+    if (failVersionNormalization && /UPDATE agent_memory\.fragment_versions/.test(sql)) {
+      throw new Error("synthetic history update failure");
+    }
+    if (/UPDATE agent_memory\.fragments/.test(sql)) {
+      return { rows: [{ id: "anchor-a", agent_id: "default", is_anchor: true }] };
+    }
+    return { rows: [] };
+  },
+  release: () => {}
+};
+
+mock.module("../../lib/tools/db.js", {
+  namedExports: {
+    getPrimaryPool: () => ({ connect: async () => client }),
+    queryWithAgentVector: async (_agentId, sql, params) => {
+      queries.push({ sql, params });
+      return { rows: [] };
+    }
+  }
+});
+
+const { FragmentWriter } = await import("../../lib/memory/write/FragmentWriter.js");
+const { MemoryRememberer } = await import("../../lib/memory/processors/MemoryRememberer.js");
+const { amendDefinition } = await import("../../lib/tools/memory-schemas.js");
+
+describe("anchor agent scope normalization", () => {
+  it("an amendment waiting behind normalization archives the newly committed shared scope", async () => {
+    queries.length = 0;
+    const stale = {
+      id: "anchor-a", content: "old", agent_id: "agent-a", key_id: "key-a",
+      workspace: "project-a", importance: 0.5, keywords: [], type: "fact"
+    };
+    lockedFragment = { ...stale, content: "committed content", agent_id: "default" };
+    await new FragmentWriter().update(stale.id, { importance: 0.7 }, "agent-a", "key-a", stale);
+    const lockIndex = queries.findIndex(q => /FOR UPDATE/.test(q.sql));
+    const archiveIndex = queries.findIndex(q => /INSERT INTO agent_memory\.fragment_versions/.test(q.sql));
+    assert.ok(lockIndex >= 0 && archiveIndex > lockIndex);
+    assert.equal(queries[archiveIndex].params[1], "committed content");
+    assert.equal(queries[archiveIndex].params.at(-2), "default");
+    assert.equal(queries[archiveIndex].params.at(-1), "project-a");
+  });
+
+  it("normalization rejects scope changed after approval before creating any version", async () => {
+    queries.length = 0;
+    const stale = { id: "anchor-a", agent_id: "agent-a", key_id: "key-a", workspace: "project-a" };
+    lockedFragment = { ...stale, workspace: "project-b" };
+    await assert.rejects(new FragmentWriter().update(
+      stale.id, { agent_id: "default" }, "agent-a", null, stale,
+      { normalizeVersionAgentToDefault: true }
+    ), /scope changed/);
+    assert.ok(queries.some(q => q.sql === "ROLLBACK"));
+    assert.equal(queries.some(q => /INSERT INTO|UPDATE agent_memory/.test(q.sql)), false);
+  });
+
+  it("a disappeared row returns null after locking without archiving", async () => {
+    queries.length = 0;
+    lockedFragment = null;
+    assert.equal(await new FragmentWriter().update(
+      "anchor-a", { importance: 0.7 }, "agent-a", null,
+      { id: "anchor-a", agent_id: "agent-a", key_id: null }
+    ), null);
+    assert.ok(queries.some(q => q.sql === "ROLLBACK"));
+    assert.equal(queries.some(q => /INSERT INTO/.test(q.sql)), false);
+  });
+
+  it("writer fallback lookup checks the caller agent and owner key before archiving", async () => {
+    queries.length = 0;
+    const result = await new FragmentWriter().update(
+      "foreign-fragment", { content: "replacement" }, "agent-a", "key-a"
+    );
+    assert.equal(result, null);
+    assert.equal(queries.length, 1);
+    assert.match(queries[0].sql, /agent_id = \$2 OR agent_id = 'default'/);
+    assert.match(queries[0].sql, /key_id = \$3/);
+    assert.deepEqual(queries[0].params, ["foreign-fragment", "agent-a", "key-a"]);
+  });
+
+  it("approved normalization changes version scope atomically without changing workspace or content", async () => {
+    queries.length = 0;
+    const existing = {
+      id: "anchor-a", content: "synthetic", type: "fact", keywords: [],
+      agent_id: "agent-a", workspace: "project-a", key_id: "key-a"
+    };
+    lockedFragment = existing;
+    await new FragmentWriter().update(
+      existing.id, { agent_id: "default" }, "agent-a", null, existing,
+      { amendedBy: "system:anchor-scope", normalizeVersionAgentToDefault: true }
+    );
+    const versionIndex = queries.findIndex(q => /UPDATE agent_memory\.fragment_versions/.test(q.sql));
+    const fragmentIndex = queries.findIndex(q => /UPDATE agent_memory\.fragments\b/.test(q.sql));
+    const commitIndex = queries.findIndex(q => q.sql === "COMMIT");
+    assert.ok(fragmentIndex < versionIndex && versionIndex < commitIndex);
+    assert.deepEqual(queries[versionIndex].params, ["anchor-a"]);
+    assert.match(queries[versionIndex].sql, /WHERE fragment_id = \$1\s*$/);
+    assert.doesNotMatch(queries[versionIndex].sql, /SET[^]*workspace|SET[^]*content|SET[^]*key_id/);
+
+    queries.length = 0;
+    failVersionNormalization = true;
+    try {
+      await assert.rejects(new FragmentWriter().update(
+        existing.id, { agent_id: "default" }, "agent-a", null, existing,
+        { normalizeVersionAgentToDefault: true }
+      ), /synthetic history update failure/);
+    } finally {
+      failVersionNormalization = false;
+    }
+    assert.ok(queries.some(q => /UPDATE agent_memory\.fragments\b/.test(q.sql)));
+    assert.ok(queries.some(q => q.sql === "ROLLBACK"));
+    assert.equal(queries.some(q => q.sql === "COMMIT"), false);
+  });
+
+  it("automatic events use the persisted fragment key for snapshots and event links", async () => {
+    const seen = [];
+    const rememberer = new MemoryRememberer({ caseEventStore: {
+      append: async event => { seen.push(event); return { event_id: "event-a" }; },
+      addEvidence: async () => {},
+      getByCase: async (_id, scope) => { seen.push(scope); return []; }
+    } });
+    await rememberer._recordCaseEvent({
+      id: "fragment-a", case_id: "case-a", type: "error", content: "synthetic",
+      key_id: null, agent_id: "default", workspace: "project-a"
+    }, "caller-key");
+    assert.equal(seen[0].key_id, null);
+    assert.equal(seen[1].keyId, null);
+    assert.equal(seen[0].source_fragment_id, "fragment-a");
+  });
+
+  it("public amend schema에 agent scope 변경 필드를 노출하지 않는다", () => {
+    assert.equal(amendDefinition.inputSchema.properties.newAgentId, undefined);
+  });
+  it("agent 변경 전 상태를 version history에 남기고 같은 트랜잭션에서 default로 변경한다", async () => {
+    queries.length = 0;
+    const writer = new FragmentWriter();
+    const existing = {
+      id: "anchor-a", content: "synthetic shared rule", topic: "synthetic-topic",
+      keywords: ["synthetic"], type: "procedure", importance: 0.9,
+      agent_id: "agent-a", is_anchor: true, key_id: null
+    };
+    lockedFragment = existing;
+
+    const result = await writer.update(
+      existing.id, { agent_id: "default" }, "agent-a", null, existing,
+      { amendedBy: "system:anchor-scope" }
+    );
+
+    const archive = queries.find(call => /INSERT INTO agent_memory\.fragment_versions/.test(call.sql));
+    const update = queries.find(call => /UPDATE agent_memory\.fragments/.test(call.sql));
+    assert.ok(archive);
+    assert.match(archive.sql, /agent_id/);
+    assert.equal(archive.params[6], "system:anchor-scope");
+    assert.equal(archive.params.at(-2), "agent-a");
+    assert.equal(archive.params.at(-1), null);
+    assert.ok(update);
+    assert.match(update.sql, /agent_id = \$2/);
+    assert.equal(update.params[1], "default");
+    assert.equal(result.agent_id, "default");
+  });
+
+  it("agent scope가 없는 fragment를 default history로 합성하지 않는다", async () => {
+    const writer = new FragmentWriter();
+    const missingScope = {
+      id: "anchor-missing", content: "synthetic", topic: "synthetic-topic",
+      keywords: [], type: "fact", importance: 0.5, key_id: null
+    };
+    await assert.rejects(
+      writer.archiveVersion(missingScope, "system"),
+      /agent scope is required/
+    );
+    await assert.rejects(
+      writer.update(missingScope.id, { content: "changed" }, "default", null, missingScope),
+      /agent scope is required/
+    );
+  });
+});
+
+describe("anchor normalization cache ordering", () => {
+  const existing = {
+    id: "anchor-b", content: "synthetic private rule", topic: "synthetic-topic",
+    keywords: ["synthetic"], type: "procedure", importance: 0.9,
+    agent_id: "agent-b", is_anchor: true, key_id: "key-b"
+  };
+
+  it("명시적인 전체 파편 이관 모드에서는 non-anchor도 정규화한다", async () => {
+    const nonAnchor = { ...existing, id: "fragment-legacy", is_anchor: false };
+    let updated = false;
+    const rememberer = new MemoryRememberer({
+      store: {
+        getById: async () => nonAnchor,
+        update: async () => {
+          updated = true;
+          return { ...nonAnchor, agent_id: "default" };
+        }
+      },
+      index: { deindex: async () => {}, index: async () => {} }
+    });
+    const result = await rememberer.normalizeFragmentAgentToDefault(
+      nonAnchor.id, "agent-b", { anchorsOnly: false }
+    );
+    assert.equal(updated, true);
+    assert.equal(result.updated, true);
+  });
+
+  it("named workspace를 inventory scope 그대로 getById에 전달한다", async () => {
+    const scoped = { ...existing, id: "anchor-workspace", workspace: "project-a" };
+    let readOptions;
+    const rememberer = new MemoryRememberer({
+      store: {
+        getById: async (...args) => {
+          readOptions = args.at(-1);
+          return scoped;
+        },
+        update: async () => ({ ...scoped, agent_id: "default" })
+      },
+      index: { deindex: async () => {}, index: async () => {} }
+    });
+
+    const result = await rememberer.normalizeFragmentAgentToDefault(
+      scoped.id, scoped.agent_id, { workspace: scoped.workspace }
+    );
+
+    assert.equal(result.updated, true);
+    assert.deepEqual(readOptions, {
+      includePeerAgents: false,
+      workspace: "project-a",
+      allWorkspaces: false
+    });
+  });
+
+  it("inventory 이후 workspace가 바뀐 파편은 정규화하지 않는다", async () => {
+    const moved = { ...existing, workspace: null };
+    let updated = false;
+    const rememberer = new MemoryRememberer({
+      store: {
+        getById: async () => moved,
+        update: async () => { updated = true; }
+      },
+      index: { deindex: async () => {}, index: async () => {} }
+    });
+
+    const result = await rememberer.normalizeFragmentAgentToDefault(
+      moved.id, moved.agent_id, { workspace: "project-a" }
+    );
+
+    assert.equal(result.updated, false);
+    assert.equal(updated, false);
+    assert.match(result.error, /expected agent scope/);
+  });
+
+  it("old private cache를 제거한 뒤 DB를 갱신하고 shared cache를 등록한다", async () => {
+    const order = [];
+    const rememberer = new MemoryRememberer({
+      store: {
+        getById: async () => existing,
+        update: async (...args) => {
+          order.push(["update", args.at(-1)]);
+          return { ...existing, agent_id: "default" };
+        }
+      },
+      index: {
+        deindex: async (...args) => order.push(["deindex", args.at(-1)]),
+        index: async (...args) => order.push(["index", args.at(-1)])
+      }
+    });
+    const result = await rememberer.normalizeAnchorAgentToDefault(existing.id, "agent-b");
+    assert.equal(result.updated, true);
+    assert.deepEqual(order.map(item => item[0]), ["deindex", "update", "index"]);
+    assert.deepEqual(order[0][1], { strict: true });
+    assert.deepEqual(order[1][1], {
+      amendedBy: "system:anchor-scope", normalizeVersionAgentToDefault: true
+    });
+    assert.deepEqual(order[2][1], { strict: true });
+  });
+
+  it("deindex 실패 시 DB update를 시작하지 않는다", async () => {
+    let updated = false;
+    const rememberer = new MemoryRememberer({
+      store: {
+        getById: async () => existing,
+        update: async () => { updated = true; }
+      },
+      index: {
+        deindex: async () => { throw new Error("synthetic cache failure"); }
+      }
+    });
+    const result = await rememberer.normalizeAnchorAgentToDefault(existing.id, "agent-b");
+    assert.equal(result.updated, false);
+    assert.equal(updated, false);
+    assert.match(result.error, /cache consistency failed/);
+  });
+
+  it("DB update 실패 시 old private cache를 strict 복원한다", async () => {
+    const order = [];
+    const rememberer = new MemoryRememberer({
+      store: {
+        getById: async () => existing,
+        update: async () => {
+          order.push("update");
+          throw new Error("synthetic database failure");
+        }
+      },
+      index: {
+        deindex: async () => order.push("deindex"),
+        index: async (fragment, _sessionId, _keyId, opts) => {
+          order.push(`restore:${fragment.agent_id}:${opts.strict}`);
+        }
+      }
+    });
+    await assert.rejects(
+      rememberer.normalizeAnchorAgentToDefault(existing.id, "agent-b"),
+      /synthetic database failure/
+    );
+    assert.deepEqual(order, ["deindex", "update", "restore:agent-b:true"]);
+  });
+
+  it("shared cache 등록 실패는 DB 변경 완료 상태를 명시한다", async () => {
+    let indexCalls = 0;
+    const rememberer = new MemoryRememberer({
+      store: {
+        getById: async () => existing,
+        update: async () => ({ ...existing, agent_id: "default" })
+      },
+      index: {
+        deindex: async () => {},
+        index: async () => {
+          indexCalls++;
+          throw new Error("synthetic cache failure");
+        }
+      }
+    });
+    const result = await rememberer.normalizeAnchorAgentToDefault(existing.id, "agent-b");
+    assert.equal(indexCalls, 1);
+    assert.equal(result.updated, true);
+    assert.equal(result.databaseUpdated, true);
+    assert.equal(result.cacheConsistent, false);
+    assert.match(result.cacheWarning, /cache consistency failed/);
+  });
+
+  it("DB update가 결과 없이 끝나도 old private cache를 strict 복원한다", async () => {
+    const order = [];
+    const rememberer = new MemoryRememberer({
+      store: {
+        getById: async () => existing,
+        update: async () => {
+          order.push("update");
+          return null;
+        }
+      },
+      index: {
+        deindex: async () => order.push("deindex"),
+        index: async (fragment, _sessionId, _keyId, opts) => {
+          order.push(`restore:${fragment.agent_id}:${opts.strict}`);
+        }
+      }
+    });
+    const result = await rememberer.normalizeAnchorAgentToDefault(existing.id, "agent-b");
+    assert.equal(result.updated, false);
+    assert.deepEqual(order, ["deindex", "update", "restore:agent-b:true"]);
+  });
+});

--- a/tests/unit/anchor-scope-cli.test.js
+++ b/tests/unit/anchor-scope-cli.test.js
@@ -1,0 +1,116 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import anchorScope, {
+  parseStrictBooleanFlag, parseSnapshotBatchSize,
+  assertNoNormalizationFailures, normalizeApprovedFragments
+} from "../../lib/cli/anchor-scope.js";
+import { parseArgs } from "../../lib/cli/parseArgs.js";
+
+describe("anchor-scope CLI safety", () => {
+  it("유효한 snapshot batch size와 기본값을 유지한다", () => {
+    assert.equal(parseSnapshotBatchSize({}), 500);
+    for (const value of [1, "1", "500", "10000", 10_000]) {
+      assert.equal(parseSnapshotBatchSize({ "batch-size": value }), Number(value));
+    }
+  });
+
+  it("잘못된 batch size를 dry-run과 실행 모두 DB 접근 전에 거부한다", async () => {
+    const invalidOptions = [
+      ["--batch-size", "-5"], ["--batch-size=-5"], ["--batch-size"],
+      ["--no-batch-size"], ["--batch-size=true"], ["--batch-size=false"],
+      ["--batch-size=1.5"], ["--batch-size=0"], ["--batch-size=10001"],
+      ["--batch-size="], ["--batch-size=NaN"], ["--batch-size=Infinity"],
+      ["--batch-size=1", "--batch-size=2"]
+    ];
+    for (const invalid of invalidOptions) {
+      for (const mode of [[], ["--backfill-snapshots"],
+        ["--backfill-snapshots", "--execute", "--approve-backfill"]]) {
+        await assert.rejects(
+          anchorScope(parseArgs([...mode, ...invalid])),
+          /--batch-size must be an integer between 1 and 10000/
+        );
+      }
+    }
+  });
+
+  it("bare boolean flag만 허용한다", () => {
+    assert.equal(parseStrictBooleanFlag({}, "execute"), false);
+    assert.equal(parseStrictBooleanFlag({ execute: true }, "execute"), true);
+    assert.equal(parseStrictBooleanFlag({ execute: false }, "execute"), false);
+  });
+
+  it("문자열 boolean과 중복 배열을 거부한다", () => {
+    for (const value of ["false", "true", [true, true], ["false", true]]) {
+      assert.throws(
+        () => parseStrictBooleanFlag({ execute: value }, "execute"),
+        /must be supplied once/
+      );
+    }
+  });
+
+  it("부분 실패를 성공 종료로 처리하지 않는다", () => {
+    assert.doesNotThrow(() => assertNoNormalizationFailures([{ updated: true }]));
+    assert.throws(
+      () => assertNoNormalizationFailures([{ updated: true, cacheConsistent: false }]),
+      /failed for 1 item/
+    );
+    assert.throws(
+      () => assertNoNormalizationFailures([{ updated: true }, { updated: false }]),
+      /failed for 1 item/
+    );
+  });
+
+  it("global/named workspace 혼합 승인은 전체 사전검증 후 순서대로 실행한다", async () => {
+    const calls = [];
+    const manager = {
+      validateFragmentAgentNormalization: async (id, agentId, opts) => {
+        calls.push(["validate", id, agentId, opts]);
+        return { valid: true };
+      },
+      normalizeFragmentAgentToDefault: async (id, agentId, opts) => {
+        calls.push(["normalize", id, agentId, opts]);
+        return { updated: true };
+      }
+    };
+    const approved = [
+      { id: "global-a", agentId: "agent-a", workspace: null },
+      { id: "workspace-b", agentId: "agent-b", workspace: "project-b" }
+    ];
+
+    const results = await normalizeApprovedFragments(manager, approved, { anchorsOnly: false });
+
+    assert.deepEqual(calls.map(call => `${call[0]}:${call[1]}`), [
+      "validate:global-a", "validate:workspace-b",
+      "normalize:global-a", "normalize:workspace-b"
+    ]);
+    assert.deepEqual(calls[0][3], {
+      anchorsOnly: false, workspace: null, allWorkspaces: false
+    });
+    assert.deepEqual(calls[1][3], {
+      anchorsOnly: false, workspace: "project-b", allWorkspaces: false
+    });
+    assert.deepEqual(results.map(result => result.id), ["global-a", "workspace-b"]);
+  });
+
+  it("후행 workspace 승인 사전검증 실패 시 어떤 항목도 변경하지 않는다", async () => {
+    const normalized = [];
+    const manager = {
+      validateFragmentAgentNormalization: async (id) => id === "workspace-b"
+        ? { valid: false, error: "scope changed" }
+        : { valid: true },
+      normalizeFragmentAgentToDefault: async (id) => {
+        normalized.push(id);
+        return { updated: true };
+      }
+    };
+
+    await assert.rejects(
+      normalizeApprovedFragments(manager, [
+        { id: "global-a", agentId: "agent-a", workspace: null },
+        { id: "workspace-b", agentId: "agent-b", workspace: "project-b" }
+      ]),
+      /preflight failed for workspace-b/
+    );
+    assert.deepEqual(normalized, []);
+  });
+});

--- a/tests/unit/case-event-snapshot-warning.test.js
+++ b/tests/unit/case-event-snapshot-warning.test.js
@@ -1,0 +1,56 @@
+import { it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+const warnings = [];
+const calls = [];
+let sourceRows = [];
+mock.module("../../lib/logger.js", {
+  defaultExport: { warn: message => warnings.push(message) },
+  namedExports: { logWarn: message => warnings.push(message) }
+});
+mock.module("../../lib/tools/db.js", {
+  namedExports: {
+    getPrimaryPool: () => ({}),
+    withTransaction: async (_pool, fn) => fn({ query: async (sql, params) => {
+      calls.push({ sql, params });
+      if (/COALESCE\(MAX/.test(sql)) return { rows: [{ next_seq: 0 }] };
+      if (/SELECT agent_id, workspace/.test(sql)) return { rows: sourceRows };
+      return { rows: [{ event_id: "event-a", sequence_no: 0 }] };
+    } })
+  }
+});
+mock.module("../../lib/memory/signals/CaseRewardBackprop.js", {
+  namedExports: { getBackprop: () => ({ backprop: async () => {} }) }
+});
+const { CaseEventStore } = await import("../../lib/memory/CaseEventStore.js");
+
+for (const source of [undefined, "private-fragment-id"]) {
+  it(`warns without exposing input when source is ${source ? "unavailable" : "absent"}`, async () => {
+    calls.length = 0;
+    warnings.length = 0;
+    sourceRows = [];
+    await new CaseEventStore().append({
+      case_id: "private-case", event_type: "error_observed", summary: "private-summary",
+      source_fragment_id: source, key_id: "private-key"
+    });
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /snapshot unavailable/);
+    assert.doesNotMatch(warnings[0], /private-/);
+    const insert = calls.find(q => /INSERT INTO/.test(q.sql));
+    assert.deepEqual(insert.params.slice(-2), [null, null]);
+    if (source) {
+      const lookup = calls.find(q => /SELECT agent_id/.test(q.sql));
+      assert.deepEqual(lookup.params, [source, "private-key"]);
+      assert.match(lookup.sql, /key_id IS NOT DISTINCT FROM \$2/);
+    }
+  });
+}
+
+it("a resolved global source has an explicit agent scope and emits no warning", async () => {
+  warnings.length = 0;
+  sourceRows = [{ agent_id: "default", workspace: null }];
+  await new CaseEventStore().append({
+    case_id: "case-a", event_type: "error_observed", source_fragment_id: "fragment-a"
+  });
+  assert.deepEqual(warnings, []);
+});

--- a/tests/unit/case-recall-workspace.test.js
+++ b/tests/unit/case-recall-workspace.test.js
@@ -34,7 +34,7 @@ mock.module("../../lib/logger.js", {
 const { CaseRecall } = await import("../../lib/memory/read/CaseRecall.js");
 
 describe("CaseRecall event workspace isolation", () => {
-  it("case 파편은 workspace로 제한하고 nullable-source 이벤트는 현재 키 그룹으로 조회", async () => {
+  it("case 파편과 nullable-source 이벤트를 immutable agent/key/workspace 범위로 조회", async () => {
     queries.length = 0;
     const cases = await new CaseRecall().buildCaseTriples(
       [{ case_id: "case-a" }],
@@ -46,9 +46,11 @@ describe("CaseRecall event workspace isolation", () => {
     assert.match(caseQuery.sql, /\(workspace = \$\d+ OR workspace IS NULL\)/);
     assert.doesNotMatch(eventQuery.sql, /JOIN agent_memory\.fragments/);
     assert.doesNotMatch(eventQuery.sql, /source_fragment_id|valid_to/);
-    assert.match(eventQuery.sql, /e\.key_id = ANY/);
-    assert.doesNotMatch(eventQuery.sql, /e\.key_id IS NULL/);
-    assert.deepEqual(eventQuery.params, [["case-a"], ["key-a"]]);
+    assert.match(eventQuery.sql, /ce\.agent_id/);
+    assert.match(eventQuery.sql, /ce\.key_id = ANY/);
+    assert.match(eventQuery.sql, /\(ce\.workspace = \$\d+ OR ce\.workspace IS NULL\)/);
+    assert.doesNotMatch(eventQuery.sql, /ce\.key_id IS NULL/);
+    assert.deepEqual(eventQuery.params, [["case-a"], "default", ["key-a"], "ws-a"]);
     assert.equal(cases[0].events[0].summary, "source-independent event");
   });
 
@@ -60,9 +62,10 @@ describe("CaseRecall event workspace isolation", () => {
 
     const eventQuery = queries[1];
     assert.doesNotMatch(eventQuery.sql, /JOIN agent_memory\.fragments/);
-    assert.doesNotMatch(eventQuery.sql, /e\.key_id (?:IS NULL|= ANY)/);
-    assert.doesNotMatch(eventQuery.sql, /workspace (?:=|IS NULL)/);
-    assert.deepEqual(eventQuery.params, [["case-a"]]);
+    assert.match(eventQuery.sql, /ce\.agent_id/);
+    assert.doesNotMatch(eventQuery.sql, /ce\.key_id (?:IS NULL|= ANY)/);
+    assert.doesNotMatch(eventQuery.sql, /ce\.workspace (?:=|IS NULL)/);
+    assert.deepEqual(eventQuery.params, [["case-a"], "default"]);
   });
 
   it("빈 키 그룹은 NULL 이벤트를 허용하지 않고 아무 이벤트도 매칭하지 않는다", async () => {
@@ -73,8 +76,8 @@ describe("CaseRecall event workspace isolation", () => {
 
     const eventQuery = queries[1];
     assert.doesNotMatch(eventQuery.sql, /JOIN agent_memory\.fragments/);
-    assert.match(eventQuery.sql, /e\.key_id = ANY/);
-    assert.doesNotMatch(eventQuery.sql, /e\.key_id IS NULL/);
-    assert.deepEqual(eventQuery.params, [["case-a"], []]);
+    assert.match(eventQuery.sql, /ce\.key_id = ANY/);
+    assert.doesNotMatch(eventQuery.sql, /ce\.key_id IS NULL/);
+    assert.deepEqual(eventQuery.params, [["case-a"], "default", [], "ws-a"]);
   });
 });

--- a/tests/unit/cli-completion.test.js
+++ b/tests/unit/cli-completion.test.js
@@ -31,16 +31,16 @@ async function captureCompletion(shellArg) {
 
 describe("completion — L6 shell completion", () => {
   // ── 서브명령 / 플래그 메타데이터 ──────────────────────────────
-  it("COMMANDS 배열에 15개 서브명령이 포함된다", () => {
-    assert.strictEqual(COMMAND_COUNT, 15);
-    assert.strictEqual(COMMANDS.length, 15);
+  it("COMMANDS 배열에 16개 서브명령이 포함된다", () => {
+    assert.strictEqual(COMMAND_COUNT, 16);
+    assert.strictEqual(COMMANDS.length, 16);
   });
 
   it("자동완성 목록이 bin/memento.js 디스패치 목록과 일치한다", () => {
     const required = [
       "serve", "migrate", "cleanup", "backfill", "stats", "health", "recall",
       "remember", "inspect", "update", "export", "import", "completion",
-      "session", "benchmark",
+      "session", "benchmark", "anchor-scope",
     ];
     for (const cmd of required) {
       assert.ok(COMMANDS.includes(cmd), `COMMANDS에 ${cmd} 누락`);

--- a/tests/unit/cli-surface-snapshot.test.js
+++ b/tests/unit/cli-surface-snapshot.test.js
@@ -64,7 +64,7 @@ function readCommandTable() {
   const block = source.match(/const COMMANDS = \{([\s\S]*?)\n\};/);
   const local = source.match(/const LOCAL_ONLY_COMMANDS = new Set\(\[([\s\S]*?)\]\)/);
   return {
-    registered: [...block[1].matchAll(/^\s*([a-z][a-z-]*):/gm)].map(m => m[1]).sort(),
+    registered: [...block[1].matchAll(/^\s*(?:['"])?([a-z][a-z-]*)(?:['"])?\s*:/gm)].map(m => m[1]).sort(),
     localOnly : [...local[1].matchAll(/"([a-z][a-z-]*)"/g)].map(m => m[1]).sort()
   };
 }

--- a/tests/unit/consolidator-split-anchor-guard.test.js
+++ b/tests/unit/consolidator-split-anchor-guard.test.js
@@ -25,6 +25,7 @@ mock.module("../../lib/tools/db.js", {
 mock.module("../../lib/config.js", {
   namedExports: {
     resolveSplitChainConfig: () => null,
+    ALLOW_LEGACY_UNBOUND_AGENT_SCOPE: false,
     LLM_PRIMARY            : "gemini-cli",
     LLM_FALLBACKS          : [],
     buildSearchPath        : () => "agent_memory, public"

--- a/tests/unit/consolidator-split-child-keywords.test.js
+++ b/tests/unit/consolidator-split-child-keywords.test.js
@@ -26,6 +26,7 @@ mock.module("../../lib/tools/db.js", {
 mock.module("../../lib/config.js", {
   namedExports: {
     resolveSplitChainConfig: () => null,
+    ALLOW_LEGACY_UNBOUND_AGENT_SCOPE: false,
     LLM_PRIMARY            : "gemini-cli",
     LLM_FALLBACKS          : [],
     /** FragmentWriter가 요구 — 이 테스트는 DB 경로를 타지 않으므로 값은 무의미 */

--- a/tests/unit/consolidator-split-child-quality.test.js
+++ b/tests/unit/consolidator-split-child-quality.test.js
@@ -31,6 +31,7 @@ mock.module("../../lib/tools/db.js", {
 mock.module("../../lib/config.js", {
   namedExports: {
     resolveSplitChainConfig: () => [{ provider: "xai" }],
+    ALLOW_LEGACY_UNBOUND_AGENT_SCOPE: false,
     LLM_PRIMARY            : "gemini-cli",
     LLM_FALLBACKS          : [],
     /** ConsolidatorGC가 키워드 추출을 위해 write 계층을 로드하므로 필요 */

--- a/tests/unit/consolidator-split-partial-yield.test.js
+++ b/tests/unit/consolidator-split-partial-yield.test.js
@@ -23,6 +23,7 @@ mock.module("../../lib/tools/db.js", {
 mock.module("../../lib/config.js", {
   namedExports: {
     resolveSplitChainConfig: () => null,
+    ALLOW_LEGACY_UNBOUND_AGENT_SCOPE: false,
     LLM_PRIMARY            : "gemini-cli",
     LLM_FALLBACKS          : [],
     /** ConsolidatorGC가 키워드 추출을 위해 write 계층을 로드하므로 필요 */

--- a/tests/unit/consolidator-split-subject-guard.test.js
+++ b/tests/unit/consolidator-split-subject-guard.test.js
@@ -27,6 +27,7 @@ mock.module("../../lib/tools/db.js", {
 mock.module("../../lib/config.js", {
   namedExports: {
     resolveSplitChainConfig: () => null,
+    ALLOW_LEGACY_UNBOUND_AGENT_SCOPE: false,
     LLM_PRIMARY            : "gemini-cli",
     LLM_FALLBACKS          : [],
     buildSearchPath        : () => "agent_memory, public"

--- a/tests/unit/context-anchor-limit.test.js
+++ b/tests/unit/context-anchor-limit.test.js
@@ -299,8 +299,8 @@ describe("ContextBuilder anchor 조회와 응답", () => {
     assert.ok(workspaceCall);
     assert.ok(globalCall);
     assert.match(workspaceCall.sql, /key_id = ANY\(\$\d+::text\[\]\)/);
-    assert.deepEqual(workspaceCall.params, [["key-a", "key-shared"], "workspace-a", 20]);
-    assert.deepEqual(globalCall.params, [["key-a", "key-shared"], 20]);
+    assert.deepEqual(workspaceCall.params, ["default", ["key-a", "key-shared"], "workspace-a", 20]);
+    assert.deepEqual(globalCall.params, ["default", ["key-a", "key-shared"], 20]);
     for (const call of calls) {
       assert.match(call.sql, /ORDER BY importance DESC, created_at DESC NULLS LAST, id COLLATE "C" ASC/);
       assert.match(call.sql, /LIMIT \$\d+/);
@@ -316,6 +316,45 @@ describe("ContextBuilder anchor 조회와 응답", () => {
     await builder.build({ _defaultWorkspace: "workspace-default" });
     assert.equal(calls.length, 2);
     assert.ok(calls.some(call => call.params.includes("workspace-default")));
+  });
+
+  it("agentId 지정 시 own + default 조건을 모든 anchor 후보 조회에 적용한다", async () => {
+    const calls = [];
+    const builder = makeBuilder(async (sql, params) => {
+      calls.push({ sql, params });
+      return { rows: [] };
+    });
+
+    await builder.build({ agentId: "agent-a", workspace: "workspace-a" });
+
+    assert.equal(calls.length, 2);
+    for (const call of calls) {
+      assert.match(call.sql, /\(agent_id = \$1 OR agent_id = 'default'\)/);
+      assert.equal(call.params[0], "agent-a");
+    }
+  });
+
+  it("peer 조회는 agent 조건만 완화하고 key/workspace 경계를 유지한다", async () => {
+    const calls = [];
+    const builder = makeBuilder(async (sql, params) => {
+      calls.push({ sql, params });
+      return { rows: [] };
+    });
+
+    await builder.build({
+      agentId: "agent-a",
+      includePeerAgents: true, _isMaster: true,
+      _keyId: "key-a",
+      _groupKeyIds: ["key-a", "key-b"],
+      workspace: "workspace-a"
+    });
+
+    assert.equal(calls.length, 2);
+    for (const call of calls) {
+      assert.match(call.sql, /peer-agent: no agent_id filter/);
+      assert.match(call.sql, /key_id = ANY\(\$\d+::text\[\]\)/);
+      assert.equal(call.params[0], "agent-a");
+    }
   });
 
   it("workspace가 없으면 전역(NULL) 후보만 단일 조회한다", async () => {

--- a/tests/unit/context-builder.test.js
+++ b/tests/unit/context-builder.test.js
@@ -23,7 +23,11 @@ import {
 
 /* ── 헬퍼: 파편 팩토리 ── */
 function frag(id, type, content, extra = {}) {
-  return { id, type, content, importance: 0.5, workspace: null, ...extra };
+  return {
+    id, type, content, importance: 0.5,
+    agent_id: "default", key_id: null, workspace: null,
+    ...extra
+  };
 }
 
 /* ── buildContextHint 단위 테스트 ── */
@@ -235,7 +239,10 @@ describe("ContextBuilder.build()", () => {
 
   it("sessionId 전달 시 working memory를 로드하고 seenIds 저장", async () => {
     indexMock.getWorkingMemory = mock.fn(async () => [
-      { id: "wm-1", content: "wm item", type: "fact", workspace: null }
+      {
+        id: "wm-1", content: "wm item", type: "fact",
+        agent_id: "default", key_id: null, workspace: null
+      }
     ]);
 
     const result = await builder.build({ sessionId: "sess-1" });
@@ -247,10 +254,10 @@ describe("ContextBuilder.build()", () => {
 
   it("working memory는 added_at 최신순, 동점이면 id 오름차순이다", async () => {
     indexMock.getWorkingMemory = mock.fn(async () => [
-      { id: "wm-b", content: "b", type: "fact", added_at: 100, workspace: null },
-      { id: "wm-old", content: "old", type: "fact", added_at: 50, workspace: null },
-      { id: "wm-a", content: "a", type: "fact", added_at: 100, workspace: null },
-      { id: "wm-new", content: "new", type: "fact", added_at: 200, workspace: null }
+      { id: "wm-b", content: "b", type: "fact", added_at: 100, agent_id: "default", key_id: null, workspace: null },
+      { id: "wm-old", content: "old", type: "fact", added_at: 50, agent_id: "default", key_id: null, workspace: null },
+      { id: "wm-a", content: "a", type: "fact", added_at: 100, agent_id: "default", key_id: null, workspace: null },
+      { id: "wm-new", content: "new", type: "fact", added_at: 200, agent_id: "default", key_id: null, workspace: null }
     ]);
 
     const result = await builder.build({ sessionId: "synthetic-session", structured: true });
@@ -271,15 +278,16 @@ describe("ContextBuilder.build()", () => {
     assert.deepEqual(sourceArgs[4], {
       workspace: "ws-a",
       allWorkspaces: false,
-      isAnchor: false
+      isAnchor: false,
+      includePeerAgents: false
     });
   });
 
   it("working memory에서 다른 workspace와 legacy entry를 제외", async () => {
     indexMock.getWorkingMemory = mock.fn(async () => [
-      { id: "global", content: "global", type: "fact", workspace: null },
-      { id: "same", content: "same", type: "fact", workspace: "ws-a" },
-      { id: "other", content: "other", type: "fact", workspace: "ws-b" },
+      { id: "global", content: "global", type: "fact", agent_id: "default", key_id: null, workspace: null },
+      { id: "same", content: "same", type: "fact", agent_id: "default", key_id: null, workspace: "ws-a" },
+      { id: "other", content: "other", type: "fact", agent_id: "default", key_id: null, workspace: "ws-b" },
       { id: "legacy", content: "legacy", type: "fact" }
     ]);
 
@@ -291,10 +299,10 @@ describe("ContextBuilder.build()", () => {
     assert.ok(!wmIds.includes("legacy"));
   });
 
-  it("allWorkspaces=true이면 모든 신규 working memory entry를 허용", async () => {
+  it("allWorkspaces=true여도 agent metadata 없는 legacy entry는 차단한다", async () => {
     indexMock.getWorkingMemory = mock.fn(async () => [
-      { id: "a", content: "a", type: "fact", workspace: "ws-a" },
-      { id: "b", content: "b", type: "fact", workspace: "ws-b" },
+      { id: "a", content: "a", type: "fact", agent_id: "default", key_id: null, workspace: "ws-a" },
+      { id: "b", content: "b", type: "fact", agent_id: "default", key_id: null, workspace: "ws-b" },
       { id: "legacy", content: "legacy", type: "fact" }
     ]);
 
@@ -304,10 +312,25 @@ describe("ContextBuilder.build()", () => {
     const ids = new Set(result.fragments.map(f => f.id));
     assert.ok(ids.has("a"));
     assert.ok(ids.has("b"));
-    assert.ok(ids.has("legacy"));
+    assert.ok(!ids.has("legacy"));
     for (const call of recallMock.mock.calls) {
       assert.equal(call.arguments[0]._isMaster, true);
     }
+  });
+
+  it("peer+allWorkspaces도 agent metadata 없는 legacy entry는 차단한다", async () => {
+    indexMock.getWorkingMemory = mock.fn(async () => [
+      { id: "peer", content: "peer", type: "fact", agent_id: "agent-b", key_id: null, workspace: "ws-b" },
+      { id: "legacy", content: "legacy", type: "fact", key_id: null, workspace: "ws-b" }
+    ]);
+
+    const result = await builder.build({
+      sessionId: "session-peer-all", agentId: "agent-a",
+      includePeerAgents: true, allWorkspaces: true, _isMaster: true
+    });
+    const ids = new Set(result.fragments.map(f => f.id));
+    assert.ok(ids.has("peer"));
+    assert.ok(!ids.has("legacy"));
   });
 
   it("중복 ID 파편은 첫 등장만 유지", async () => {
@@ -396,7 +419,8 @@ describe("ContextBuilder.build()", () => {
     assert.deepEqual(storeMock.searchBySource.mock.calls[0].arguments[4], {
       workspace: "synthetic-workspace",
       allWorkspaces: false,
-      isAnchor: false
+      isAnchor: false,
+      includePeerAgents: false
     });
   });
 

--- a/tests/unit/episode-continuity-scope.test.js
+++ b/tests/unit/episode-continuity-scope.test.js
@@ -1,0 +1,58 @@
+import { describe, it, mock, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+const calls = [];
+const responses = [];
+mock.module("../../lib/tools/db.js", {
+  exports: {
+    getPrimaryPool: () => ({
+      query: async (sql, params) => {
+        calls.push({ sql, params });
+        return responses.shift() ?? { rows: [] };
+      }
+    })
+  }
+});
+mock.module("../../lib/logger.js", {
+  exports: { logWarn: () => {} }
+});
+
+const { linkEpisodeMilestone, _lastEventCacheForTest } = await import(
+  "../../lib/memory/processors/EpisodeContinuityService.js"
+);
+
+beforeEach(() => {
+  calls.length = 0;
+  responses.length = 0;
+  _lastEventCacheForTest().clear();
+});
+
+describe("EpisodeContinuityService immutable scope", () => {
+  it("fragment identity를 검증하고 event snapshot과 previous-event scope를 저장한다", async () => {
+    responses.push(
+      { rows: [{
+        summary: "synthetic milestone", workspace: "workspace-a", topic: "topic-a",
+        agent_id: "agent-a", key_id: "key-a"
+      }] },
+      { rows: [{ event_id: "event-new" }] },
+      { rows: [{ event_id: "event-old" }] },
+      { rows: [] }
+    );
+    await linkEpisodeMilestone("fragment-a", "agent-a", "key-a", "session-a");
+    assert.match(calls[0].sql, /agent_id = \$2/);
+    assert.match(calls[0].sql, /key_id IS NOT DISTINCT FROM \$3/);
+    assert.deepEqual(calls[0].params, ["fragment-a", "agent-a", "key-a"]);
+    assert.match(calls[1].sql, /key_id, agent_id, workspace/);
+    assert.deepEqual(calls[1].params.slice(-3), ["key-a", "agent-a", "workspace-a"]);
+    assert.match(calls[2].sql, /ce\.agent_id = \$1/);
+    assert.match(calls[2].sql, /ce\.key_id IS NOT DISTINCT FROM \$2/);
+    assert.match(calls[2].sql, /ce\.workspace = \$3/);
+    assert.doesNotMatch(calls[2].sql, /JOIN\s+agent_memory\.fragments/);
+  });
+
+  it("passed agent/key와 일치하는 fragment가 없으면 event를 만들지 않는다", async () => {
+    responses.push({ rows: [] });
+    await linkEpisodeMilestone("fragment-b", "agent-b", "key-b", "session-b");
+    assert.equal(calls.length, 1);
+  });
+});

--- a/tests/unit/fragment-history.test.js
+++ b/tests/unit/fragment-history.test.js
@@ -32,6 +32,6 @@ describe("fragment history", () => {
     });
 
     assert.equal(result.current.id, "frag-peer");
-    assert.deepEqual(captured[4], { includePeerAgents: true });
+    assert.deepEqual(captured[4], { includePeerAgents: true, workspace: null, allWorkspaces: false });
   });
 });

--- a/tests/unit/fragment-index-group.test.js
+++ b/tests/unit/fragment-index-group.test.js
@@ -453,3 +453,40 @@ describe("getRecent", () => {
     assert.ok(result.length <= 3, `count=3인데 ${result.length}개 반환됨`);
   });
 });
+
+describe("strict cache consistency", () => {
+  it("실제 Redis가 ready가 아니면 index/deindex를 실패 처리한다", async () => {
+    const redis = newRedis();
+    redis.status = "reconnecting";
+    const idx = new FragmentIndex();
+    await assert.rejects(
+      idx.index(makeFragment("strict-a", "topic-a", "fact"), null, "key-a", { strict: true }),
+      /Redis index unavailable/
+    );
+    await assert.rejects(
+      idx.deindex("strict-a", [], "topic-a", "fact", "key-a", { strict: true }),
+      /Redis index unavailable/
+    );
+  });
+
+  it("pipeline 개별 오류도 strict 모드에서 실패 처리한다", async () => {
+    const redis = newRedis();
+    redis.pipeline = () => {
+      const pipeline = {
+        sadd: () => pipeline,
+        zadd: () => pipeline,
+        expire: () => pipeline,
+        srem: () => pipeline,
+        zrem: () => pipeline,
+        del: () => pipeline,
+        exec: async () => [[new Error("synthetic cache failure"), null]]
+      };
+      return pipeline;
+    };
+    const idx = new FragmentIndex();
+    await assert.rejects(
+      idx.index(makeFragment("strict-b", "topic-b", "fact"), null, "key-b", { strict: true }),
+      /synthetic cache failure/
+    );
+  });
+});

--- a/tests/unit/fragment-index-wm-evict.test.js
+++ b/tests/unit/fragment-index-wm-evict.test.js
@@ -89,13 +89,37 @@ function newRedis() {
 
 async function seedWm(idx, sessionId, items) {
   for (const item of items) {
-    await idx.addToWorkingMemory(sessionId, item);
+    await idx.addToWorkingMemory(sessionId, {
+      agent_id: "default", key_id: null, workspace: null, ...item
+    });
   }
 }
 
 describe("FragmentIndex.evictWorkingMemoryItems", () => {
 
   beforeEach(() => { newRedis(); });
+
+  it("scope metadata 누락은 캐시를 건너뛰고 호출자에게 예외를 전파하지 않는다", async () => {
+    const idx = new FragmentIndex();
+    await assert.doesNotReject(
+      idx.addToWorkingMemory("session-missing-scope", {
+        id: "wm-missing", content: "synthetic", type: "fact"
+      })
+    );
+    assert.deepEqual(await idx.getWorkingMemory("session-missing-scope"), []);
+  });
+
+  it("agent/key/workspace metadata를 Working Memory에서 그대로 round-trip한다", async () => {
+    const idx = new FragmentIndex();
+    await idx.addToWorkingMemory("session-scope", {
+      id: "wm-scope", content: "synthetic", type: "fact",
+      agent_id: "default", key_id: "key-a", workspace: "workspace-a"
+    });
+    const [item] = await idx.getWorkingMemory("session-scope");
+    assert.equal(item.agent_id, "default");
+    assert.equal(item.key_id, "key-a");
+    assert.equal(item.workspace, "workspace-a");
+  });
 
   it("지정된 id만 evict하고 나머지는 보존한다", async () => {
     const idx = new FragmentIndex();

--- a/tests/unit/fragment-search-scope-integrity.test.js
+++ b/tests/unit/fragment-search-scope-integrity.test.js
@@ -132,8 +132,8 @@ describe("_searchL2 ID 보충 조회 scope 정합", () => {
 
   it("topic 일치 파편만 통과한다", async () => {
     const rows = [
-      { id: "f1", content: "x", topic: "memento-mcp", type: "fact", created_at: "2026-08-01T00:00:00Z", workspace: null },
-      { id: "f2", content: "y", topic: "arcana",      type: "fact", created_at: "2026-08-01T00:00:00Z", workspace: null },
+      { id: "f1", content: "x", topic: "memento-mcp", type: "fact", agent_id: "default", created_at: "2026-08-01T00:00:00Z", workspace: null },
+      { id: "f2", content: "y", topic: "arcana",      type: "fact", agent_id: "default", created_at: "2026-08-01T00:00:00Z", workspace: null },
     ];
     const results = await FragmentSearch.prototype._searchL2.call(
       { store: makeStore(rows) },
@@ -146,8 +146,8 @@ describe("_searchL2 ID 보충 조회 scope 정합", () => {
 
   it("type 필터도 보충 조회에 적용된다", async () => {
     const rows = [
-      { id: "f1", content: "x", topic: "t", type: "error",     created_at: "2026-08-01T00:00:00Z", workspace: null },
-      { id: "f2", content: "y", topic: "t", type: "procedure", created_at: "2026-08-01T00:00:00Z", workspace: null },
+      { id: "f1", content: "x", topic: "t", type: "error",     agent_id: "default", created_at: "2026-08-01T00:00:00Z", workspace: null },
+      { id: "f2", content: "y", topic: "t", type: "procedure", agent_id: "default", created_at: "2026-08-01T00:00:00Z", workspace: null },
     ];
     const results = await FragmentSearch.prototype._searchL2.call(
       { store: makeStore(rows) },
@@ -160,8 +160,8 @@ describe("_searchL2 ID 보충 조회 scope 정합", () => {
 
   it("timeRange가 보충 조회에 적용된다", async () => {
     const rows = [
-      { id: "old", content: "x", created_at: "2026-01-01T00:00:00Z", workspace: null },
-      { id: "new", content: "y", created_at: "2026-08-10T00:00:00Z", workspace: null },
+      { id: "old", content: "x", agent_id: "default", created_at: "2026-01-01T00:00:00Z", workspace: null },
+      { id: "new", content: "y", agent_id: "default", created_at: "2026-08-10T00:00:00Z", workspace: null },
     ];
     const results = await FragmentSearch.prototype._searchL2.call(
       { store: makeStore(rows) },

--- a/tests/unit/fragment-sql-boundary.test.js
+++ b/tests/unit/fragment-sql-boundary.test.js
@@ -52,6 +52,7 @@ const ALLOWED = {
   "memory/processors/EpisodeContinuityService.js": 1,
   "memory/processors/MemoryRecaller.js": 1,
   "memory/read/CaseRecall.js": 2,
+  "memory/CaseEventStore.js": 1,
   "memory/read/ContextBuilder.js": 1,
   "memory/read/FragmentReader.js": 13,
   "memory/read/HistoryReconstructor.js": 1,

--- a/tests/unit/fragment-sql-boundary.test.js
+++ b/tests/unit/fragment-sql-boundary.test.js
@@ -54,7 +54,7 @@ const ALLOWED = {
   "memory/read/CaseRecall.js": 2,
   "memory/CaseEventStore.js": 1,
   "memory/read/ContextBuilder.js": 1,
-  "memory/read/FragmentReader.js": 13,
+  "memory/read/FragmentReader.js": 14,
   "memory/read/HistoryReconstructor.js": 1,
   "memory/read/KeyNameEnricher.js": 1,
   "memory/read/RecallSuggestionEngine.js": 2,
@@ -67,7 +67,7 @@ const ALLOWED = {
   "memory/signals/SpreadingActivation.js": 2,
   "memory/write/BatchRememberProcessor.js": 1,
   "memory/write/ConflictResolver.js": 2,
-  "memory/write/FragmentWriter.js": 21,
+  "memory/write/FragmentWriter.js": 22, // archive 전에 현재 파편을 FOR UPDATE로 재조회
   "memory/write/RememberPostProcessor.js": 1,
   "tools/reconstruct.js": 1,
   "tools/resources.js": 4,

--- a/tests/unit/idempotency-contract.test.js
+++ b/tests/unit/idempotency-contract.test.js
@@ -35,7 +35,7 @@ const EXEMPT = {
   memory_consolidate: "대상 집합이 호출 시점에 결정된다"
 };
 
-const tools = getToolsDefinition(null);
+const tools = getToolsDefinition(null, true);
 const byName = new Map(tools.map(t => [t.name, t]));
 
 /**

--- a/tests/unit/initialize-tool-count.test.js
+++ b/tests/unit/initialize-tool-count.test.js
@@ -1,0 +1,30 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { dispatchJsonRpc } from "../../lib/jsonrpc.js";
+
+describe("initialize tool count follows the session tools/list", () => {
+  for (const [name, session] of [
+    ["master", { keyId: null, isMaster: true, permissions: null }],
+    ["scoped key", { keyId: "test-key", isMaster: false, permissions: ["read"] }],
+    ["legacy session without explicit master identity", { keyId: null }],
+    ["scoped recall-only mode", { keyId: "test-key", isMaster: false, mode: "recall-only" }],
+    ["master audit mode", { keyId: null, isMaster: true, mode: "audit" }],
+    ["scoped key cannot assume master-only mode", { keyId: "test-key", isMaster: false, mode: "audit" }]
+  ]) {
+    test(name, async () => {
+      const initialized = await dispatchJsonRpc({
+        id: 1, method: "initialize", params: {
+          protocolVersion: "2025-11-25",
+          isMaster: true, mode: "audit"
+        }
+      }, session);
+      const listed = await dispatchJsonRpc({ id: 2, method: "tools/list" }, session);
+      assert.equal(initialized.kind, "ok");
+      assert.equal(listed.kind, "ok");
+      const count = Number(initialized.response.result.serverInfo.description.match(/도구 (\d+)개/)[1]);
+      assert.equal(count, listed.response.result.tools.length);
+      assert.equal(listed.response.result.tools.some(tool => tool.name === "apply_update"),
+        session.isMaster === true);
+    });
+  }
+});

--- a/tests/unit/key-scope-single-source.test.js
+++ b/tests/unit/key-scope-single-source.test.js
@@ -44,7 +44,6 @@ const ALLOWED = {
   "memory/signals/SearchParamAdaptor.js": 1,
   "memory/write/FragmentWriter.js": 4,
   "symbolic/ClaimStore.js": 4,
-  "tools/resources.js": 2,
 };
 
 /** 격리 조건을 직접 쓴 것으로 보이는 줄인지 판정한다. */

--- a/tests/unit/key-scope-single-source.test.js
+++ b/tests/unit/key-scope-single-source.test.js
@@ -37,7 +37,6 @@ const ALLOWED = {
   "memory/CaseEventStore.js": 2,
   "memory/consolidate/MemoryConsolidator.js": 2,
   "memory/link/ContradictionDetector.js": 2,
-  "memory/processors/EpisodeContinuityService.js": 1,
   "memory/read/FragmentReader.js": 1,
   "memory/read/GraphNeighborSearch.js": 1,
   "memory/read/RecallSuggestionEngine.js": 2,

--- a/tests/unit/legacy-sse-auth.test.js
+++ b/tests/unit/legacy-sse-auth.test.js
@@ -4,6 +4,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { safeCompare } from "../../lib/auth.js";
+import { isLegacySseAuthDisabledMaster } from "../../lib/handlers/sse-handler.js";
 
 describe("safeCompare", () => {
   it("동일 문자열 비교 시 true", () => {
@@ -17,5 +18,16 @@ describe("safeCompare", () => {
   it("빈 문자열 처리", () => {
     assert.strictEqual(safeCompare("", ""), true);
     assert.strictEqual(safeCompare("", "x"), false);
+  });
+});
+
+describe("Legacy SSE fail-closed master decision", () => {
+  it("ACCESS_KEY 누락만으로 master가 되지 않는다", () => {
+    assert.equal(isLegacySseAuthDisabledMaster("", false), false);
+  });
+
+  it("명시적 AUTH_DISABLED에서만 master를 허용한다", () => {
+    assert.equal(isLegacySseAuthDisabledMaster("", true), true);
+    assert.equal(isLegacySseAuthDisabledMaster("synthetic-key", true), false);
   });
 });

--- a/tests/unit/mcp-handler-batch-json.test.js
+++ b/tests/unit/mcp-handler-batch-json.test.js
@@ -48,10 +48,19 @@ describe("mcp-handler batch_remember routing", () => {
     const req = { method: "POST", headers: { accept: "application/json, text/event-stream" } };
     const res = { setHeader: mock.fn(), end: mock.fn(), statusCode: 200, writable: true, destroyed: false };
 
-    await handleToolCallForTest(req, res, msg, "sess-1", null, null);
+    await handleToolCallForTest(req, res, msg, "sess-1", "key-a", null, {
+      groupKeyIds: ["key-a"], permissions: ["write"], defaultWorkspace: "workspace-a",
+      isMaster: false
+    });
 
     assert.equal(sendJSONFn.mock.callCount(), 1, "표준 JSON 응답 경로 사용");
     assert.equal(writeSSEEventFn.mock.callCount(), 0, "커스텀 SSE 프레임 미사용");
+    const sessionData = dispatchJsonRpcFn.mock.calls[0].arguments[1];
+    assert.deepEqual(sessionData.groupKeyIds, ["key-a"]);
+    assert.deepEqual(sessionData.permissions, ["write"]);
+    assert.equal(sessionData.defaultWorkspace, "workspace-a");
+    assert.equal(sessionData.authenticated, true);
+    assert.equal(sessionData.isMaster, false);
   });
 });
 

--- a/tests/unit/mcp-handler-characterization.test.js
+++ b/tests/unit/mcp-handler-characterization.test.js
@@ -165,7 +165,7 @@ describe("deriveTokenKey — 미커버 분기 보강", () => {
 
   it("keyId가 null(master)이면 'master:hash' 형식이다", () => {
     const req = { headers: { authorization: "Bearer master-token-xyz" } };
-    const key = deriveTokenKey(req, {}, { keyId: null });
+    const key = deriveTokenKey(req, {}, { keyId: null, isMaster: true });
 
     assert.ok(key,                    "null이면 안 된다");
     assert.ok(key.startsWith("master:"), `'master:' prefix 기대: ${key}`);
@@ -175,7 +175,7 @@ describe("deriveTokenKey — 미커버 분기 보강", () => {
 
   it("memento-access-key 헤더 + keyId=null → 'master:hash'", () => {
     const req = { headers: { "memento-access-key": "ak-test-123" } };
-    const key = deriveTokenKey(req, {}, { keyId: null });
+    const key = deriveTokenKey(req, {}, { keyId: null, isMaster: true });
 
     assert.ok(key.startsWith("master:"), `'master:' prefix: ${key}`);
   });

--- a/tests/unit/mcp-keyid-injection.test.js
+++ b/tests/unit/mcp-keyid-injection.test.js
@@ -22,7 +22,8 @@ describe("injectSessionContext — _keyId 주입 보장", () => {
     sessionKeyId:     42,
     sessionGroupKeyIds: [10, 20],
     sessionPermissions: ["read", "write"],
-    sessionDefaultWorkspace: "ws-main"
+    sessionDefaultWorkspace: "ws-main",
+    sessionIsMaster: false
   };
 
   it("arguments가 null인 경우 새 객체 생성 후 _keyId 주입", () => {
@@ -68,7 +69,8 @@ describe("injectSessionContext — 클라이언트 위조 차단", () => {
     sessionKeyId:     99,
     sessionGroupKeyIds: [1],
     sessionPermissions: ["read"],
-    sessionDefaultWorkspace: "ws-real"
+    sessionDefaultWorkspace: "ws-real",
+    sessionIsMaster: false
   };
 
   it("클라이언트가 전송한 _keyId='victim_key' 무시하고 서버 keyId로 덮어씀", () => {

--- a/tests/unit/mcp-session-recovery.test.js
+++ b/tests/unit/mcp-session-recovery.test.js
@@ -16,6 +16,7 @@
 
 import { describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
+import { hasSessionIdentityMismatch } from "../../lib/handlers/mcp-handler.js";
 
 /** ─────────────────────────────────────────────────────────────────
  *  sessionData 구조 검증 (TC4: lastReflectedAt 초기화)
@@ -94,7 +95,7 @@ async function simulateRecovery({
 
   if (redisEnabled && redisSession !== undefined) {
     const existingRedis = redisSession;
-    if (existingRedis && existingRedis.keyId !== incomingKeyId) {
+    if (hasSessionIdentityMismatch(existingRedis, authResult)) {
       mockRecordTI("session_recover_keyid_mismatch");
       mockRecordSR("keyid_mismatch");
       return "keyid_mismatch";
@@ -111,7 +112,7 @@ describe("세션 복구 분기 — keyId 교차 검증", () => {
   it("TC1: keyId 일치 → same_id_success", async () => {
     const result = await simulateRecovery({
       redisSession: { keyId: "key-A", authenticated: true },
-      authResult:   { valid: true, keyId: "key-A" },
+      authResult:   { valid: true, keyId: "key-A", isMaster: false },
     });
     assert.strictEqual(result, "same_id_success");
   });
@@ -119,7 +120,7 @@ describe("세션 복구 분기 — keyId 교차 검증", () => {
   it("TC2: 다른 keyId → keyid_mismatch (403)", async () => {
     const result = await simulateRecovery({
       redisSession: { keyId: "key-A", authenticated: true },
-      authResult:   { valid: true, keyId: "key-B" },
+      authResult:   { valid: true, keyId: "key-B", isMaster: false },
     });
     assert.strictEqual(result, "keyid_mismatch");
   });
@@ -127,7 +128,7 @@ describe("세션 복구 분기 — keyId 교차 검증", () => {
   it("TC3: Redis에 기존 세션 없음 (null) + 인증 성공 → same_id_success", async () => {
     const result = await simulateRecovery({
       redisSession: null,
-      authResult:   { valid: true, keyId: "key-C" },
+      authResult:   { valid: true, keyId: "key-C", isMaster: false },
     });
     assert.strictEqual(result, "same_id_success");
   });
@@ -143,7 +144,7 @@ describe("세션 복구 분기 — keyId 교차 검증", () => {
   it("TC5: Redis 비활성화 + keyId 불일치 → same_id_success (검증 스킵)", async () => {
     const result = await simulateRecovery({
       redisSession : { keyId: "key-A", authenticated: true },
-      authResult   : { valid: true, keyId: "key-B" },
+      authResult   : { valid: true, keyId: "key-B", isMaster: false },
       redisEnabled : false,
     });
     assert.strictEqual(result, "same_id_success");
@@ -151,10 +152,18 @@ describe("세션 복구 분기 — keyId 교차 검증", () => {
 
   it("TC6: master 키(keyId=null) 복구 → same_id_success", async () => {
     const result = await simulateRecovery({
-      redisSession: { keyId: null, authenticated: true },
-      authResult:   { valid: true, keyId: null },
+      redisSession: { keyId: null, isMaster: true, authenticated: true },
+      authResult:   { valid: true, keyId: null, isMaster: true },
     });
     assert.strictEqual(result, "same_id_success");
+  });
+
+  it("TC7: keyId=null이어도 OAuth non-master와 master identity는 교차 복구되지 않는다", async () => {
+    const result = await simulateRecovery({
+      redisSession: { keyId: null, isMaster: true, authenticated: true },
+      authResult: { valid: true, keyId: null, isMaster: false }
+    });
+    assert.strictEqual(result, "keyid_mismatch");
   });
 
 });

--- a/tests/unit/openapi-master-tools.test.js
+++ b/tests/unit/openapi-master-tools.test.js
@@ -1,0 +1,23 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildSpec } from "../../lib/openapi.js";
+
+function advertisedNames(spec) {
+  return spec.paths["/mcp"].post["x-mcp-tools"].map(tool => tool.name);
+}
+
+describe("OpenAPI master-only tool advertisement", () => {
+  it("일반 API key에는 requiresMaster 도구를 광고하지 않는다", () => {
+    const names = advertisedNames(buildSpec(false, ["read", "admin"]));
+    for (const name of ["memory_stats", "memory_consolidate", "check_update", "apply_update"]) {
+      assert.equal(names.includes(name), false);
+    }
+  });
+
+  it("명시적 master에는 master 도구를 광고한다", () => {
+    const names = advertisedNames(buildSpec(true, null));
+    for (const name of ["memory_stats", "memory_consolidate", "check_update", "apply_update"]) {
+      assert.equal(names.includes(name), true);
+    }
+  });
+});

--- a/tests/unit/peer-agent-auth.test.js
+++ b/tests/unit/peer-agent-auth.test.js
@@ -1,0 +1,175 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+// This suite verifies the explicit strict-mode deployment contract.
+process.env.MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE = "false";
+const { dispatchJsonRpc, handleToolsCall, handleToolsList } = await import("../../lib/jsonrpc.js");
+const { TOOL_REGISTRY } = await import("../../lib/tool-registry.js");
+
+const tenantCtx = {
+  authenticated: true,
+  keyId: "synthetic-key", groupKeyIds: ["synthetic-key"], permissions: ["read"],
+  defaultWorkspace: "workspace-a", mode: null, sessionId: "session-a", isMaster: false
+};
+const masterCtx = {
+  authenticated: true,
+  keyId: null, groupKeyIds: null, permissions: null,
+  defaultWorkspace: null, mode: null, sessionId: "session-master", isMaster: true
+};
+
+function withStubbedTool(name, handler, run) {
+  const original = TOOL_REGISTRY.get(name);
+  TOOL_REGISTRY.set(name, { ...original, handler });
+  return Promise.resolve(run()).finally(() => TOOL_REGISTRY.set(name, original));
+}
+
+describe("trusted tool context authorization", () => {
+  it("sessionData 없는 직접 dispatch를 거부한다", async () => {
+    const result = await dispatchJsonRpc({
+      jsonrpc: "2.0", id: 1, method: "tools/call",
+      params: { name: "recall", arguments: { _keyId: null, _permissions: null } }
+    });
+    assert.equal(result.response.error.code, -32600);
+  });
+
+  it("API key에 바인딩되지 않은 non-master OAuth identity는 진단 가능한 권한 오류를 반환한다", async () => {
+    const result = await dispatchJsonRpc({
+      jsonrpc: "2.0", id: 11, method: "tools/call",
+      params: { name: "recall", arguments: {} }
+    }, {
+      ...tenantCtx, keyId: null, permissions: null, isMaster: false
+    });
+    assert.equal(result.response.error.code, -32001);
+    assert.match(result.response.error.message, /API-key binding/);
+    assert.match(result.response.error.message, /OAuth sessions must be bound to an API key/);
+  });
+
+  it("불완전한 master identity와 API key 권한 오류를 OAuth 바인딩 오류로 표시하지 않는다", async () => {
+    for (const context of [
+      { ...masterCtx, keyId: "synthetic-key" },
+      { ...masterCtx, permissions: ["read"] },
+      { ...tenantCtx, permissions: null }
+    ]) {
+      const result = await dispatchJsonRpc({
+        jsonrpc: "2.0", id: 12, method: "tools/call",
+        params: { name: "recall", arguments: {} }
+      }, context);
+      assert.equal(result.response.error.code, -32001);
+      assert.doesNotMatch(result.response.error.message, /OAuth|API-key binding/);
+      assert.match(result.response.error.message, /context/);
+    }
+  });
+
+  it("객체가 아닌 arguments는 도구 실행 없이 Invalid params로 반환한다", async () => {
+    let calls = 0;
+    await withStubbedTool("recall", async () => {
+      calls++;
+      return { success: true };
+    }, async () => {
+      for (const args of ["text", "", 1, 0, true, false, null, [], [{}]]) {
+        const result = await dispatchJsonRpc({
+          jsonrpc: "2.0", id: 13, method: "tools/call",
+          params: { name: "recall", arguments: args }
+        }, tenantCtx);
+        assert.equal(result.response.error.code, -32602);
+        assert.equal(result.response.error.message, "Tool arguments must be an object");
+      }
+      assert.equal(calls, 0);
+    });
+  });
+
+  it("arguments 생략은 빈 객체와 동일하게 인증 컨텍스트를 전달한다", async () => {
+    const received = [];
+    await withStubbedTool("recall", async args => {
+      received.push(args);
+      return { success: true };
+    }, async () => {
+      for (const params of [{ name: "recall" }, { name: "recall", arguments: {} }]) {
+        const result = await dispatchJsonRpc({
+          jsonrpc: "2.0", id: 14, method: "tools/call", params
+        }, tenantCtx);
+        assert.equal(result.response.error, undefined);
+      }
+      assert.equal(received.length, 2);
+      assert.deepEqual(received[0], received[1]);
+      assert.equal(received[0]._keyId, tenantCtx.keyId);
+      assert.equal(received[0]._isMaster, false);
+    });
+  });
+
+  it("일반 API key의 peer 조회와 non-default agent 읽기·쓰기를 거부한다", async () => {
+    for (const [name, permissions] of [["recall", ["read"]], ["remember", ["write"]]]) {
+      await assert.rejects(
+        handleToolsCall(
+          { name, arguments: { agentId: "agent-b", includePeerAgents: name === "recall" } },
+          { ...tenantCtx, permissions }
+        ),
+        error => error.code === -32001
+      );
+    }
+  });
+
+  it("일반 API key의 default agent는 허용하고 내부 필드는 서버값으로 덮는다", async () => {
+    await withStubbedTool("recall", async args => ({
+      success: true,
+      keyId: args._keyId,
+      groupKeyIds: args._groupKeyIds,
+      workspace: args._defaultWorkspace
+    }), async () => {
+      const result = await handleToolsCall({
+        name: "recall",
+        arguments: {
+          agentId: "default", _keyId: null, _groupKeyIds: ["forged"],
+          _permissions: null, _defaultWorkspace: "forged"
+        }
+      }, tenantCtx);
+      const payload = JSON.parse(result.content[0].text);
+      assert.equal(payload.keyId, "synthetic-key");
+      assert.deepEqual(payload.groupKeyIds, ["synthetic-key"]);
+      assert.equal(payload.workspace, "workspace-a");
+    });
+  });
+
+  it("read-only API context에서 _permissions=null 위조로 write 권한을 얻지 못한다", async () => {
+    const result = await dispatchJsonRpc({
+      jsonrpc: "2.0", id: 2, method: "tools/call",
+      params: { name: "remember", arguments: { _permissions: null, content: "synthetic" } }
+    }, tenantCtx);
+    assert.equal(result.response.error.code, -32001);
+  });
+
+  it("master는 임의 agent와 peer flag를 handler까지 전달한다", async () => {
+    await withStubbedTool("recall", async args => ({
+      success: true, agentId: args.agentId, peer: args.includePeerAgents
+    }), async () => {
+      const result = await handleToolsCall({
+        name: "recall", arguments: { agentId: "agent-a", includePeerAgents: true }
+      }, masterCtx);
+      const payload = JSON.parse(result.content[0].text);
+      assert.equal(payload.agentId, "agent-a");
+      assert.equal(payload.peer, true);
+    });
+  });
+
+  it("admin permission도 requiresMaster 도구의 explicit master 조건을 우회하지 못한다", async () => {
+    for (const name of ["apply_update", "check_update", "memory_stats"]) {
+      await withStubbedTool(name, async () => ({ success: true }), async () => {
+        await assert.rejects(
+          handleToolsCall(
+            { name, arguments: {} },
+            { ...tenantCtx, permissions: ["admin"] }
+          ),
+          error => error.code === -32001 && /requires master/.test(error.message)
+        );
+      });
+    }
+  });
+
+  it("non-master tools/list에서 requiresMaster 도구를 숨긴다", () => {
+    const tenantNames = handleToolsList({}, tenantCtx).tools.map(tool => tool.name);
+    const masterNames = handleToolsList({}, masterCtx).tools.map(tool => tool.name);
+    for (const name of ["apply_update", "check_update", "memory_stats"]) {
+      assert.equal(tenantNames.includes(name), false);
+      assert.equal(masterNames.includes(name), true);
+    }
+  });
+});

--- a/tests/unit/point-read-workspace.test.js
+++ b/tests/unit/point-read-workspace.test.js
@@ -1,0 +1,119 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+
+import { MemoryRecaller } from "../../lib/memory/processors/MemoryRecaller.js";
+
+let managerCalls = [];
+mock.module("../../lib/memory/MemoryManager.js", {
+  namedExports: {
+    MemoryManager: {
+      getInstance: () => ({
+        fragmentHistory: async args => {
+          managerCalls.push(args);
+          return { current: { id: args.id } };
+        },
+        graphExplore: async args => {
+          managerCalls.push(args);
+          return { startId: args.startId, nodes: [], edges: [], count: 0 };
+        }
+      })
+    }
+  }
+});
+const { tool_fragmentHistory, tool_graphExplore } = await import("../../lib/tools/memory.js");
+
+const pointReads = [
+  { method: "fragmentHistory", args: { id: "fragment-a" }, tool: tool_fragmentHistory },
+  { method: "graphExplore", args: { startId: "fragment-a" }, tool: tool_graphExplore }
+];
+
+function createRecaller() {
+  const calls = [];
+  const fragment = { id: "fragment-a", workspace: "project-a", agent_id: "agent-a" };
+  const store = {
+    getHistory: async (...args) => {
+      calls.push(args);
+      return { current: fragment, versions: [], superseded_by_chain: [] };
+    },
+    getById: async (...args) => {
+      calls.push(args);
+      return fragment;
+    },
+    getRCAChain: async (...args) => {
+      calls.push(args);
+      return [{ id: "fragment-b", relation_type: "resolved_by", workspace: "project-b" }];
+    }
+  };
+  return { recaller: new MemoryRecaller({ store }), calls };
+}
+
+for (const { method, args, tool } of pointReads) {
+  describe(`${method} workspace authorization`, () => {
+    it("master allWorkspaces는 point lookup과 후속 hydration에 전달된다", async () => {
+      const { recaller, calls } = createRecaller();
+      const result = await recaller[method]({
+        ...args, _isMaster: true, allWorkspaces: true,
+        agentId: "agent-a", workspace: "ignored-project", _defaultWorkspace: "ignored-default"
+      });
+      assert.equal(result.error, undefined);
+      assert.equal(calls.length, method === "graphExplore" ? 2 : 1);
+      for (const call of calls) {
+        assert.equal(call[1], "agent-a");
+        assert.equal(call[2], null);
+        assert.deepEqual(call[4], {
+          workspace: null, allWorkspaces: true, includePeerAgents: false, _isMaster: true
+        });
+      }
+    });
+
+    it("직접 processor 호출도 비master allWorkspaces를 저장소 접근 전에 거부한다", async () => {
+      const { recaller, calls } = createRecaller();
+      for (const auth of [{ _keyId: "key-a", _isMaster: false }, { _keyId: null }]) {
+        await assert.rejects(
+          recaller[method]({ ...args, ...auth, allWorkspaces: true }),
+          { code: "WORKSPACE_SCOPE_FORBIDDEN" }
+        );
+      }
+      assert.equal(calls.length, 0);
+    });
+
+    it("명시 workspace와 key 기본값의 우선순위를 유지하고 생략은 global-only다", async () => {
+      for (const [scope, expected] of [
+        [{ workspace: "project-a", _defaultWorkspace: "project-b" }, "project-a"],
+        [{ _defaultWorkspace: "project-b" }, "project-b"],
+        [{}, null]
+      ]) {
+        const { recaller, calls } = createRecaller();
+        await recaller[method]({
+          ...args, ...scope, agentId: "agent-a", _keyId: "key-a", _groupKeyIds: ["key-a", "key-b"]
+        });
+        for (const call of calls) {
+          assert.equal(call[1], "agent-a");
+          assert.equal(call[2], "key-a");
+          assert.deepEqual(call[3], ["key-a", "key-b"]);
+          assert.deepEqual(call[4], {
+            workspace: expected, allWorkspaces: false, includePeerAgents: false
+          });
+        }
+      }
+    });
+
+    it("공개 도구는 allWorkspaces/peer 권한 위반을 manager 호출 전에 거부한다", async () => {
+      managerCalls = [];
+      for (const scope of [{ allWorkspaces: true }, { includePeerAgents: true }]) {
+        const result = await tool({ ...args, ...scope, _keyId: "key-a", _isMaster: false });
+        assert.equal(result.success, false);
+        assert.match(result.error, /master/);
+      }
+      assert.equal(managerCalls.length, 0);
+    });
+
+    it("공개 도구는 master allWorkspaces 요청을 허용한다", async () => {
+      managerCalls = [];
+      const result = await tool({ ...args, _isMaster: true, allWorkspaces: true });
+      assert.equal(result.success, true);
+      assert.equal(managerCalls.length, 1);
+      assert.equal(managerCalls[0].allWorkspaces, true);
+    });
+  });
+}

--- a/tests/unit/rbac.test.js
+++ b/tests/unit/rbac.test.js
@@ -15,8 +15,12 @@ describe("RBAC permission check", () => {
   });
 
   it("allows everything for null permissions (master key)", () => {
-    assert.ok(checkPermission(null, "memory_consolidate").allowed);
-    assert.ok(checkPermission(null, "remember").allowed);
+    assert.ok(checkPermission(null, "memory_consolidate", true).allowed);
+    assert.ok(checkPermission(null, "remember", true).allowed);
+  });
+
+  it("null permissions without explicit master is denied", () => {
+    assert.equal(checkPermission(null, "recall", false).allowed, false);
   });
 
   it("admin permission implies write and read", () => {

--- a/tests/unit/recall-contradiction-hint.test.js
+++ b/tests/unit/recall-contradiction-hint.test.js
@@ -123,7 +123,7 @@ describe("hasPendingContradictions", () => {
     assert.equal(queryCalls.length, 1);
     assert.match(queryCalls[0].sql, /relation_type = 'contradicts'/);
     assert.match(queryCalls[0].sql, /valid_to IS NULL/);
-    assert.deepEqual(queryCalls[0].params, [["f1", "f2"]]);
+    assert.deepEqual(queryCalls[0].params, [["f1", "f2"], "default"]);
   });
 
   it("pool 부재 시 false로 강등 (힌트는 advisory)", async () => {

--- a/tests/unit/recall-peer-agent-isolation-integration.test.js
+++ b/tests/unit/recall-peer-agent-isolation-integration.test.js
@@ -252,6 +252,7 @@ async function runHotCacheSearch(includePeerAgents) {
   };
   if (includePeerAgents !== undefined) {
     query.includePeerAgents = includePeerAgents;
+    query._isMaster = true;
   }
 
   return search.search(query);
@@ -442,7 +443,7 @@ describe("GraphNeighborSearch SQL 및 최종 RRF 격리", () => {
       10,
       "agent-a",
       ["key-1"],
-      { workspace: "ws-a", includePeerAgents: true }
+      { workspace: "ws-a", includePeerAgents: true, _isMaster: true }
     );
 
     const { sql, params } = graphQueries.at(-1);
@@ -575,7 +576,7 @@ describe("LinkStore SQL agent/workspace 격리", () => {
       null,
       "agent-a",
       ["key-1"],
-      { workspace: "ws-a", includePeerAgents: true }
+      { workspace: "ws-a", includePeerAgents: true, _isMaster: true }
     );
 
     const { sql, params } = vectorQueries.at(-1);
@@ -700,7 +701,7 @@ describe("MemoryRecaller 기본 includeLinks 최종 병합 격리", () => {
       agentId          : "agent-a",
       workspace        : "ws-a",
       keywords         : ["scope-isolation"],
-      includePeerAgents: true
+      includePeerAgents: true, _isMaster: true
     });
 
     assert.deepEqual(
@@ -710,7 +711,7 @@ describe("MemoryRecaller 기본 includeLinks 최종 병합 격리", () => {
     assert.deepEqual(calls[0][4], {
       workspace         : "ws-a",
       allWorkspaces     : false,
-      includePeerAgents : true
+      includePeerAgents: true, _isMaster: true
     });
   });
 

--- a/tests/unit/recall-peer-agents.test.js
+++ b/tests/unit/recall-peer-agents.test.js
@@ -31,7 +31,7 @@ const { FragmentReader } = await import("../../lib/memory/read/FragmentReader.js
 const { FragmentStore }  = await import("../../lib/memory/write/FragmentStore.js");
 
 const AGENT_COND = /agent_id = \$\d+ OR (f\.)?agent_id = 'default'/;
-const PEER_COND  = /\$\d+::text IS NOT NULL/;
+const PEER_COND  = /peer-agent: no [a-z._]+ filter/;
 
 function lastSql() {
   return captured[captured.length - 1].sql;
@@ -50,20 +50,20 @@ describe("FragmentReader includePeerAgents", () => {
   });
 
   it("searchByKeywords includePeerAgents=true면 격리 완화", async () => {
-    await reader.searchByKeywords(["k"], { agentId: "a1", includePeerAgents: true });
+    await reader.searchByKeywords(["k"], { agentId: "a1", includePeerAgents: true, _isMaster: true });
     assert.doesNotMatch(lastSql(), AGENT_COND);
     assert.match(lastSql(), PEER_COND);
   });
 
   it("searchByTopic includePeerAgents=true면 격리 완화", async () => {
-    await reader.searchByTopic("t", { agentId: "a1", includePeerAgents: true });
+    await reader.searchByTopic("t", { agentId: "a1", includePeerAgents: true, _isMaster: true });
     assert.doesNotMatch(lastSql(), AGENT_COND);
   });
 
   it("searchBySemantic includePeerAgents=true면 f.agent_id 격리 완화", async () => {
     const vec = new Array(4).fill(0.1);
     await reader.searchBySemantic(vec, {
-      limit: 5, minSimilarity: 0.3, agentId: "a1", includePeerAgents: true
+      limit: 5, minSimilarity: 0.3, agentId: "a1", includePeerAgents: true, _isMaster: true
     });
     assert.doesNotMatch(lastSql(), AGENT_COND);
     assert.match(lastSql(), PEER_COND);
@@ -76,7 +76,7 @@ describe("FragmentReader includePeerAgents", () => {
   });
 
   it("getByIds opts.includePeerAgents=true면 격리 완화", async () => {
-    await reader.getByIds(["f1"], "a1", null, [], { includePeerAgents: true });
+    await reader.getByIds(["f1"], "a1", null, [], { includePeerAgents: true, _isMaster: true });
     assert.doesNotMatch(lastSql(), AGENT_COND);
   });
 
@@ -89,13 +89,13 @@ describe("FragmentReader includePeerAgents", () => {
   });
 
   it("searchByTimeRange includePeerAgents=true면 격리 완화", async () => {
-    await reader.searchByTimeRange("2026-01-01", "2026-02-01", { agentId: "a1", includePeerAgents: true });
+    await reader.searchByTimeRange("2026-01-01", "2026-02-01", { agentId: "a1", includePeerAgents: true, _isMaster: true });
     assert.doesNotMatch(lastSql(), AGENT_COND);
   });
 
   it("FragmentStore.getByIds가 includePeerAgents 옵션을 전달", async () => {
     const store = new FragmentStore();
-    await store.getByIds(["f1"], "a1", null, [], { includePeerAgents: true });
+    await store.getByIds(["f1"], "a1", null, [], { includePeerAgents: true, _isMaster: true });
     assert.doesNotMatch(lastSql(), AGENT_COND);
     assert.match(lastSql(), PEER_COND);
   });
@@ -104,14 +104,14 @@ describe("FragmentReader includePeerAgents", () => {
     const store = new FragmentStore();
     const vec = new Array(4).fill(0.1);
     await store.searchBySemantic(vec, {
-      limit: 5, minSimilarity: 0.3, agentId: "a1", includePeerAgents: true
+      limit: 5, minSimilarity: 0.3, agentId: "a1", includePeerAgents: true, _isMaster: true
     });
     assert.doesNotMatch(lastSql(), AGENT_COND);
     assert.match(lastSql(), PEER_COND);
   });
 
   it("includePeerAgents=true여도 keyId 테넌트 필터는 유지", async () => {
-    await reader.searchByKeywords(["k"], { agentId: "a1", keyId: "key-1", includePeerAgents: true });
+    await reader.searchByKeywords(["k"], { agentId: "a1", keyId: "key-1", includePeerAgents: true, _isMaster: true });
     assert.match(lastSql(), /key_id/);
   });
 });

--- a/tests/unit/rememberer-characterization.test.js
+++ b/tests/unit/rememberer-characterization.test.js
@@ -126,11 +126,18 @@ describe("scope=session — Working Memory 경로", async () => {
       topic    : "session-test",
       type     : "fact",
       scope    : "session",
-      sessionId: "sess-abc-001"
+      sessionId: "sess-abc-001",
+      agentId  : "default",
+      _keyId   : "key-a",
+      _defaultWorkspace: "workspace-a"
     });
 
     assert.strictEqual(insertCalled, false, "DB insert가 호출되면 안 된다");
     assert.ok(deps.index.addToWorkingMemory.mock.calls.length > 0, "addToWorkingMemory가 호출돼야 한다");
+    const wmFragment = deps.index.addToWorkingMemory.mock.calls[0].arguments[1];
+    assert.equal(wmFragment.agent_id, "default");
+    assert.equal(wmFragment.key_id, "key-a");
+    assert.equal(wmFragment.workspace, "workspace-a");
     assert.strictEqual(result.scope,    "session");
     assert.strictEqual(result.ttl_tier, "session");
     assert.deepStrictEqual(result.conflicts, []);
@@ -475,5 +482,93 @@ describe("skipConflictDetection=true — detectConflicts 미호출", async () =>
     });
 
     assert.ok(detectFn.mock.calls.length > 0, "detectConflicts가 호출돼야 한다");
+  });
+});
+
+describe("amend case event source scope", async () => {
+  const { MemoryRememberer } = await import("../../lib/memory/processors/MemoryRememberer.js");
+
+  it("master amend도 event/source snapshot에 실제 fragment 소유 key를 사용한다", async () => {
+    const appended = [];
+    const existing = {
+      id: "owned-fragment", content: "검증할 파편", topic: "scope",
+      keywords: ["scope"], type: "fact", importance: 0.8,
+      key_id: "tenant-key", agent_id: "agent-a", workspace: "project-a",
+      case_id: "case-a", session_id: "session-a", assertion_status: "observed"
+    };
+    const deps = buildDeps({
+      store: {
+        getById: async () => existing,
+        update: async () => ({ ...existing, assertion_status: "verified" })
+      },
+      top: {
+        caseEventStore: {
+          append: async event => {
+            appended.push(event);
+            return { event_id: "event-a" };
+          },
+          addEvidence: async () => {}
+        }
+      }
+    });
+
+    const result = await new MemoryRememberer(deps).amend({
+      id: existing.id,
+      assertionStatus: "verified",
+      agentId: "agent-a",
+      _keyId: null,
+      _isMaster: true
+    });
+
+    assert.equal(result.updated, true);
+    assert.equal(appended.length, 1);
+    assert.equal(appended[0].key_id, "tenant-key");
+    assert.equal(appended[0].source_fragment_id, "owned-fragment");
+  });
+});
+
+describe("auto case assignment scope forwarding", async () => {
+  const { MemoryRememberer } = await import("../../lib/memory/processors/MemoryRememberer.js");
+
+  it("조회와 error backfill에 동일한 agent/key-group/workspace 범위를 전달한다", async () => {
+    const calls = [];
+    const deps = buildDeps({
+      store: {
+        findCaseIdBySessionTopic: async (...args) => {
+          calls.push(["case", ...args]);
+          return null;
+        },
+        findErrorFragmentsBySessionTopic: async (...args) => {
+          calls.push(["errors", ...args]);
+          return ["error-a"];
+        },
+        updateCaseId: async (...args) => {
+          calls.push(["update", ...args]);
+          return true;
+        }
+      }
+    });
+    const rememberer = new MemoryRememberer(deps);
+    const result = await rememberer._autoAssignCaseId({
+      type: "procedure", topic: "scope", agentId: "agent-a",
+      workspace: "project-a"
+    }, "session-a", "key-a", ["key-a", "key-b"]);
+    await Promise.resolve();
+
+    assert.ok(result.caseId);
+    const expectedScope = {
+      agentId: "agent-a", includePeerAgents: false,
+      workspace: "project-a", allWorkspaces: false
+    };
+    assert.deepEqual(calls[0], [
+      "case", "session-a", "scope", "key-a", ["key-a", "key-b"], expectedScope
+    ]);
+    assert.deepEqual(calls[1], [
+      "errors", "session-a", "scope", "key-a", ["key-a", "key-b"], expectedScope
+    ]);
+    assert.deepEqual(calls[2], [
+      "update", "error-a", result.caseId, "key-a",
+      { ...expectedScope, groupKeyIds: ["key-a", "key-b"] }
+    ]);
   });
 });

--- a/tests/unit/resources-agent-scope.test.js
+++ b/tests/unit/resources-agent-scope.test.js
@@ -1,0 +1,96 @@
+import { describe, it, mock, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+const calls = [];
+mock.module("../../lib/tools/db.js", {
+  exports: {
+    getPrimaryPool: () => ({
+      query: async (sql, params) => {
+        calls.push({ sql, params });
+        return { rows: [] };
+      }
+    }),
+    getBatchPool: () => null,
+    getPoolStats: () => ({}),
+    queryWithAgentVector: async () => ({ rows: [] }),
+    withTransaction: async (_pool, fn) => fn({ query: async () => ({ rows: [] }) }),
+    shutdownPool: async () => {}
+  }
+});
+
+const { handleResourcesRead, dispatchJsonRpc } = await import("../../lib/jsonrpc.js");
+
+const tenant = {
+  authenticated: true,
+  keyId: "synthetic-key",
+  groupKeyIds: ["synthetic-key"],
+  permissions: ["read"],
+  defaultWorkspace: "workspace-a",
+  mode: null,
+  sessionId: "session-a",
+  isMaster: false
+};
+
+beforeEach(() => { calls.length = 0; });
+
+describe("resources/read trusted agent scope", () => {
+  it("stats/topics에 default agent, key, workspace 범위를 적용한다", async () => {
+    for (const uri of ["memory://stats", "memory://topics"]) {
+      await handleResourcesRead({ uri }, tenant);
+      const call = calls.at(-1);
+      assert.match(call.sql, /f\.agent_id = \$1/);
+      assert.match(call.sql, /f\.key_id/);
+      assert.match(call.sql, /f\.workspace/);
+      assert.deepEqual(call.params, [
+        "default", "synthetic-key", ["synthetic-key"], "workspace-a"
+      ]);
+    }
+  });
+
+  it("workspace가 없으면 전역(NULL) resource만 조회한다", async () => {
+    await handleResourcesRead(
+      { uri: "memory://stats" },
+      { ...tenant, defaultWorkspace: null }
+    );
+    assert.match(calls[0].sql, /f\.workspace IS NULL/);
+    assert.deepEqual(calls[0].params, [
+      "default", "synthetic-key", ["synthetic-key"]
+    ]);
+  });
+
+  it("client resource params로 peer/master/session identity를 위조할 수 없다", async () => {
+    const result = await dispatchJsonRpc({
+      jsonrpc: "2.0", id: 1, method: "resources/read",
+      params: {
+        uri: "memory://stats", includePeerAgents: true,
+        _isMaster: true, _keyId: null, _permissions: null
+      }
+    }, tenant);
+    assert.equal(result.response.error.code, -32001);
+    assert.equal(calls.length, 0);
+  });
+
+  it("trusted context가 없거나 identity 조합이 모순이면 fail-closed한다", async () => {
+    await assert.rejects(
+      handleResourcesRead({ uri: "memory://stats" }),
+      error => error.code === -32600
+    );
+    for (const bad of [
+      { ...tenant, keyId: null },
+      { ...tenant, isMaster: true, permissions: null }
+    ]) {
+      await assert.rejects(
+        handleResourcesRead({ uri: "memory://stats" }, bad),
+        error => error.code === -32001
+      );
+    }
+    assert.equal(calls.length, 0);
+  });
+
+  it("write-only session은 resource read 권한이 없다", async () => {
+    await assert.rejects(
+      handleResourcesRead({ uri: "memory://stats" }, { ...tenant, permissions: ["write"] }),
+      error => error.code === -32001
+    );
+  });
+});

--- a/tests/unit/search-event-recorder.test.js
+++ b/tests/unit/search-event-recorder.test.js
@@ -198,6 +198,16 @@ describe("buildSearchEvent", () => {
         assert.ok(event.filter_keys.includes("is_anchor"));
     });
 
+    it("effective agent scope와 peer flag를 기록한다", () => {
+        const own = buildSearchEvent({ agentId: "agent-a" }, [], {});
+        assert.strictEqual(own.effective_agent_scope, "specific+default");
+        assert.strictEqual(own.include_peer_agents, false);
+
+        const peer = buildSearchEvent({ agentId: "agent-a", includePeerAgents: true, _isMaster: true }, [], {});
+        assert.strictEqual(peer.effective_agent_scope, "all-agents");
+        assert.strictEqual(peer.include_peer_agents, true);
+    });
+
     it("L1 전용 폴백 경로도 올바르게 파싱된다", () => {
         const event = buildSearchEvent(
             { keywords: ["k"] },

--- a/tests/unit/search-traces-agent-scope.test.js
+++ b/tests/unit/search-traces-agent-scope.test.js
@@ -1,0 +1,84 @@
+import { describe, it, mock, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+const calls = [];
+mock.module("../../lib/tools/db.js", {
+  exports: {
+    getPrimaryPool: () => ({
+      query: async (sql, params) => {
+        calls.push({ sql, params });
+        return { rows: [] };
+      }
+    }),
+    getBatchPool: () => null,
+    getPoolStats: () => ({}),
+    queryWithAgentVector: async () => ({ rows: [] }),
+    withTransaction: async (_pool, fn) => fn({ query: async () => ({ rows: [] }) }),
+    shutdownPool: async () => {}
+  }
+});
+
+const { tool_reconstructHistory, tool_searchTraces } = await import("../../lib/tools/reconstruct.js");
+const { MemoryManager } = await import("../../lib/memory/MemoryManager.js");
+
+beforeEach(() => { calls.length = 0; });
+
+describe("search_traces agent scope", () => {
+  it("agent 생략은 default-only이고 key/workspace 범위를 유지한다", async () => {
+    const result = await tool_searchTraces({
+      _keyId: "key-a", _groupKeyIds: ["key-a"], _defaultWorkspace: "workspace-a"
+    });
+    assert.equal(result.success, true);
+    assert.match(calls[0].sql, /f\.agent_id = \$1/);
+    assert.match(calls[0].sql, /f\.key_id/);
+    assert.match(calls[0].sql, /f\.workspace/);
+    assert.equal(calls[0].params[0], "default");
+  });
+
+  it("specific agent는 own+default를 검색한다", async () => {
+    await tool_searchTraces({
+      agentId: "agent-a", _keyId: "key-a", _groupKeyIds: ["key-a"]
+    });
+    assert.match(calls[0].sql, /\(f\.agent_id = \$1 OR f\.agent_id = 'default'\)/);
+    assert.match(calls[0].sql, /f\.workspace IS NULL/);
+  });
+
+  it("승인된 peer 모드는 agent만 완화하고 key/workspace는 유지한다", async () => {
+    await tool_searchTraces({
+      agentId: "agent-a", includePeerAgents: true,
+      _keyId: "key-a", _groupKeyIds: ["key-a"], _defaultWorkspace: "workspace-a",
+      _isMaster: true
+    });
+    assert.match(calls[0].sql, /peer-agent: no f\.agent_id filter/);
+    assert.match(calls[0].sql, /f\.key_id/);
+    assert.match(calls[0].sql, /f\.workspace/);
+  });
+});
+
+describe("reconstruct_history scope forwarding", () => {
+  it("tool entry가 master allWorkspaces를 facade 호출에 보존한다", async () => {
+    const originalGetInstance = MemoryManager.getInstance;
+    let received;
+    MemoryManager.getInstance = () => ({
+      reconstructHistory: async params => {
+        received = params;
+        return {
+          ordered_timeline: [], causal_chains: [], unresolved_branches: [],
+          supporting_fragments: [], case_events: [], event_dag: [], summary: "empty"
+        };
+      }
+    });
+    try {
+      const result = await tool_reconstructHistory({
+        caseId: "case-all", allWorkspaces: true, _isMaster: true,
+        _keyId: null, _groupKeyIds: null
+      });
+      assert.equal(result.success, true);
+      assert.equal(received.allWorkspaces, true);
+      assert.equal(received._isMaster, true);
+      assert.equal(received.workspace, null);
+    } finally {
+      MemoryManager.getInstance = originalGetInstance;
+    }
+  });
+});

--- a/tests/unit/session-identity-boundaries.test.js
+++ b/tests/unit/session-identity-boundaries.test.js
@@ -1,0 +1,118 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createStreamableSessionWithId,
+  rotateSession,
+  streamableSessions,
+  closeStreamableSession
+} from "../../lib/sessions.js";
+import { reanchorReusedSession } from "../../lib/handlers/mcp-handler.js";
+
+afterEach(async () => {
+  await Promise.all([...streamableSessions.keys()].map(id => closeStreamableSession(id)));
+});
+
+describe("session rotate identity boundary", () => {
+  it("다른 API key와 master/non-master mismatch를 403으로 거부한다", async () => {
+    await createStreamableSessionWithId(
+      "session-a", true, "key-a", ["key-a"], ["read"], "workspace-a", null, null, false
+    );
+    await createStreamableSessionWithId(
+      "session-master", true, null, null, null, null, null, null, true
+    );
+    await createStreamableSessionWithId(
+      "session-oauth", true, null, null, null, null, null, null, false
+    );
+    for (const [sessionId, requesterIdentity] of [
+      ["session-a", { keyId: "key-b", isMaster: false }],
+      ["session-master", { keyId: null, isMaster: false }],
+      ["session-a", { keyId: null, isMaster: true }],
+      ["session-oauth", { keyId: null, isMaster: false }]
+    ]) {
+      await assert.rejects(
+        rotateSession(sessionId, { requesterIdentity }),
+        error => error.statusCode === 403
+      );
+      assert.equal(streamableSessions.has(sessionId), true);
+    }
+  });
+
+  it("exact identity만 회전하고 fresh 권한과 기존 세션 컨텍스트를 함께 보존한다", async () => {
+    await createStreamableSessionWithId(
+      "session-a", true, "key-a", ["stale-group"], ["admin"],
+      "session-workspace", "header-selected-mode", null, false
+    );
+    const rotated = await rotateSession("session-a", {
+      requesterIdentity: {
+        keyId: "key-a", isMaster: false, groupKeyIds: ["key-a", "key-group"],
+        permissions: ["read"], defaultWorkspace: "key-default-workspace", mode: "key-default-mode"
+      }
+    });
+    const fresh = streamableSessions.get(rotated.newSessionId);
+    assert.equal(streamableSessions.has("session-a"), false);
+    assert.equal(fresh.keyId, "key-a");
+    assert.deepEqual(fresh.groupKeyIds, ["key-a", "key-group"]);
+    assert.deepEqual(fresh.permissions, ["read"]);
+    assert.equal(fresh.defaultWorkspace, "session-workspace");
+    assert.equal(fresh.mode, "header-selected-mode");
+    assert.equal(fresh.isMaster, false);
+    assert.equal(rotated.workspace, "session-workspace");
+    assert.equal(rotated.mode, "header-selected-mode");
+  });
+
+  it("master 회전은 기존 workspace와 mode를 보존한다", async () => {
+    await createStreamableSessionWithId(
+      "session-master-context", true, null, ["stale-master-group"], ["admin"],
+      "workspace-master", "audit", null, true
+    );
+    const rotated = await rotateSession("session-master-context", {
+      reason: "synthetic-rotation",
+      requesterIdentity: {
+        keyId: null, isMaster: true,
+        groupKeyIds: ["fresh-master-group"], permissions: ["read"]
+      }
+    });
+    const fresh = streamableSessions.get(rotated.newSessionId);
+    assert.deepEqual(fresh.groupKeyIds, ["fresh-master-group"]);
+    assert.deepEqual(fresh.permissions, ["read"]);
+    assert.equal(fresh.defaultWorkspace, "workspace-master");
+    assert.equal(fresh.mode, "audit");
+    assert.equal(rotated.reason, "synthetic-rotation");
+  });
+});
+
+describe("token initialize identity reanchor", () => {
+  it("재사용 세션의 전체 auth context를 fresh 값으로 교체한 뒤 persist한다", async () => {
+    const stale = {
+      keyId: "key-a", groupKeyIds: ["stale-group"], permissions: ["admin"],
+      defaultWorkspace: "stale-workspace", mode: "audit", isMaster: true
+    };
+    let persisted = null;
+    await reanchorReusedSession(stale, {
+      keyId: "key-a",
+      groupKeyIds: ["key-a"],
+      permissions: ["read"],
+      defaultWorkspace: "workspace-a",
+      mode: "recall-only",
+      isMaster: false
+    }, async session => {
+      persisted = { ...session };
+      return true;
+    });
+    assert.deepEqual(stale.groupKeyIds, ["key-a"]);
+    assert.deepEqual(stale.permissions, ["read"]);
+    assert.equal(stale.defaultWorkspace, "workspace-a");
+    assert.equal(stale.mode, "recall-only");
+    assert.equal(stale.isMaster, false);
+    assert.deepEqual(persisted, stale);
+  });
+
+  it("Redis persist callback의 boolean false를 성공으로 취급하지 않는다", async () => {
+    await assert.rejects(
+      reanchorReusedSession({}, {
+        keyId: "key-a", groupKeyIds: ["key-a"], permissions: ["read"], isMaster: false
+      }, async () => false),
+      /persistence failed/
+    );
+  });
+});

--- a/tests/unit/session-linker-token-reuse.test.js
+++ b/tests/unit/session-linker-token-reuse.test.js
@@ -102,7 +102,7 @@ describe("deriveTokenKey — initialize.params.accessKey", () => {
     const req = { headers: {} };
     const msg = { method: "initialize", params: { accessKey: "params-access-key" } };
 
-    const key = deriveTokenKey(req, msg, { keyId: null });
+    const key = deriveTokenKey(req, msg, { keyId: null, isMaster: true });
 
     assert.ok(key, "initialize.params.accessKey에서 tokenKey 추출 필요");
     assert.ok(key.startsWith("master:"), `master 네임스페이스 사용: ${key}`);
@@ -123,7 +123,7 @@ describe("deriveTokenKey — sha256 해시 특성", () => {
     const rawToken = "super-secret-bearer-token";
     const req      = { headers: { authorization: `Bearer ${rawToken}` } };
 
-    const key = deriveTokenKey(req, {}, { keyId: null });
+    const key = deriveTokenKey(req, {}, { keyId: null, isMaster: true });
 
     assert.ok(key, "tokenKey가 생성되어야 한다");
     assert.ok(!key.includes(rawToken), "원문 토큰이 tokenKey에 포함되면 안 된다");
@@ -136,8 +136,14 @@ describe("deriveTokenKey — sha256 해시 특성", () => {
     const req1 = { headers: { authorization: `Bearer ${rawToken}` } };
     const req2 = { headers: { authorization: `Bearer ${rawToken}` } };
 
-    const key1 = deriveTokenKey(req1, {}, { keyId: null });
-    const key2 = deriveTokenKey(req2, {}, { keyId: null });
+    const key1 = deriveTokenKey(req1, {}, { keyId: null, isMaster: true });
+    const key2 = deriveTokenKey(req2, {}, { keyId: null, isMaster: true });
+
+    assert.notStrictEqual(
+      deriveTokenKey(req1, {}, { keyId: null, isMaster: false }),
+      key1,
+      "non-API OAuth identity must not share the master namespace"
+    );
 
     assert.strictEqual(key1, key2, "동일 토큰은 동일 tokenKey");
     assert.strictEqual(key1, expected, "sha256 16자 해시와 일치");

--- a/tests/unit/session-redis-failclosed.test.js
+++ b/tests/unit/session-redis-failclosed.test.js
@@ -1,0 +1,101 @@
+import { describe, it, mock, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+const redisState = { saveResult: true, deletes: [] };
+
+mock.module("../../lib/config.js", {
+  exports: {
+    SESSION_TTL_MS: 60_000,
+    REDIS_ENABLED: true,
+    REDIS_SESSION_FAIL_CLOSED: true,
+    CACHE_SESSION_TTL: 60,
+    SSE_HEARTBEAT_INTERVAL_MS: 60_000,
+    SSE_MAX_HEARTBEAT_FAILURES: 3,
+    IDLE_REFLECT_HOURS: 24,
+    SUPPORTED_PROTOCOL_VERSIONS: ["2025-11-25"]
+  }
+});
+mock.module("../../lib/redis.js", {
+  exports: {
+    saveSession: async () => redisState.saveResult,
+    getSession: async () => null,
+    deleteSession: async id => {
+      redisState.deletes.push(id);
+      return id !== "session-old";
+    }
+  }
+});
+mock.module("../../lib/memory/processors/AutoReflect.js", {
+  exports: { autoReflect: async () => null }
+});
+mock.module("../../lib/logger.js", {
+  exports: { logInfo: () => {}, logWarn: () => {} }
+});
+mock.module("../../lib/metrics.js", {
+  exports: {
+    recordSessionIdleReflect: () => {},
+    recordProtocolVersionReanchored: () => {}
+  }
+});
+
+const {
+  createStreamableSessionWithId,
+  rotateSession,
+  streamableSessions
+} = await import("../../lib/sessions.js");
+
+beforeEach(() => {
+  redisState.saveResult = true;
+  redisState.deletes = [];
+  streamableSessions.clear();
+});
+afterEach(() => { streamableSessions.clear(); });
+
+describe("Redis session boolean fail-closed", () => {
+  it("create save=false면 local session을 제거하고 실패한다", async () => {
+    redisState.saveResult = false;
+    await assert.rejects(
+      createStreamableSessionWithId(
+        "session-failed", true, "key-a", ["key-a"], ["read"], null, null, null, false
+      ),
+      error => error.statusCode === 503 && /persistence failed/.test(error.message)
+    );
+    assert.equal(streamableSessions.has("session-failed"), false);
+  });
+
+  it("rotate old delete=false면 new session을 정리하고 old session을 유지한다", async () => {
+    await createStreamableSessionWithId(
+      "session-old", true, "key-a", ["key-a"], ["read"], null, null, null, false
+    );
+    await assert.rejects(
+      rotateSession("session-old", {
+        requesterIdentity: {
+          keyId: "key-a", isMaster: false, groupKeyIds: ["key-a"], permissions: ["read"]
+        }
+      }),
+      error => error.statusCode === 503
+    );
+    assert.equal(streamableSessions.has("session-old"), true);
+    assert.deepEqual([...streamableSessions.keys()], ["session-old"]);
+    assert.equal(redisState.deletes[0], "session-old");
+    assert.equal(redisState.deletes.length, 2);
+    assert.notEqual(redisState.deletes[1], "session-old");
+  });
+
+  it("rotate의 new session 저장 실패도 503으로 반환하고 old session을 유지한다", async () => {
+    await createStreamableSessionWithId(
+      "session-old", true, "key-a", ["key-a"], ["read"], null, null, null, false
+    );
+    redisState.saveResult = false;
+    await assert.rejects(
+      rotateSession("session-old", {
+        requesterIdentity: {
+          keyId: "key-a", isMaster: false, groupKeyIds: ["key-a"], permissions: ["read"]
+        }
+      }),
+      error => error.statusCode === 503
+    );
+    assert.equal(streamableSessions.has("session-old"), true);
+    assert.deepEqual([...streamableSessions.keys()], ["session-old"]);
+  });
+});

--- a/tests/unit/session-redis-fallback.test.js
+++ b/tests/unit/session-redis-fallback.test.js
@@ -1,0 +1,49 @@
+import { describe, it, mock, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+mock.module("../../lib/config.js", {
+  exports: {
+    SESSION_TTL_MS: 60_000,
+    REDIS_ENABLED: true,
+    REDIS_SESSION_FAIL_CLOSED: false,
+    CACHE_SESSION_TTL: 60,
+    SSE_HEARTBEAT_INTERVAL_MS: 60_000,
+    SSE_MAX_HEARTBEAT_FAILURES: 3,
+    IDLE_REFLECT_HOURS: 24,
+    SUPPORTED_PROTOCOL_VERSIONS: ["2025-11-25"]
+  }
+});
+mock.module("../../lib/redis.js", {
+  exports: {
+    saveSession: async () => false,
+    getSession: async () => null,
+    deleteSession: async () => true
+  }
+});
+mock.module("../../lib/memory/processors/AutoReflect.js", {
+  exports: { autoReflect: async () => null }
+});
+mock.module("../../lib/logger.js", {
+  exports: { logInfo: () => {}, logWarn: () => {} }
+});
+mock.module("../../lib/metrics.js", {
+  exports: {
+    recordSessionIdleReflect: () => {},
+    recordProtocolVersionReanchored: () => {}
+  }
+});
+
+const { createStreamableSessionWithId, streamableSessions } = await import("../../lib/sessions.js");
+
+afterEach(() => streamableSessions.clear());
+
+describe("Redis session availability fallback", () => {
+  it("기본 정책에서는 Redis 저장 실패에도 in-memory 세션을 유지한다", async () => {
+    await assert.doesNotReject(
+      createStreamableSessionWithId(
+        "session-fallback", true, "key-a", ["key-a"], ["read"], null, null, null, false
+      )
+    );
+    assert.equal(streamableSessions.has("session-fallback"), true);
+  });
+});

--- a/tests/unit/tool-contract-snapshot.test.js
+++ b/tests/unit/tool-contract-snapshot.test.js
@@ -69,7 +69,7 @@ export function normalizeToolContract(tools) {
 function buildSnapshot() {
   return {
     scoped: normalizeToolContract(getToolsDefinition("some-key-id")),
-    master: normalizeToolContract(getToolsDefinition(null))
+    master: normalizeToolContract(getToolsDefinition(null, true))
   };
 }
 
@@ -98,7 +98,9 @@ describe("도구 계약 스냅샷", () => {
     const scopedNames = Object.keys(current.scoped);
     const masterNames = Object.keys(current.master);
     const extra       = masterNames.filter(n => !scopedNames.includes(n));
-    assert.deepEqual(extra.sort(), ["apply_update", "check_update"]);
+    assert.deepEqual(extra.sort(), [
+      "apply_update", "check_update", "memory_consolidate", "memory_stats"
+    ]);
   });
 
   test("정규화는 설명 문구를 계약에 포함하지 않는다", () => {

--- a/tests/unit/tool-contract-snapshot.test.js
+++ b/tests/unit/tool-contract-snapshot.test.js
@@ -34,6 +34,7 @@ function normalizeProperty(schema) {
   if (!schema || typeof schema !== "object") return {};
   const out = {};
   if (schema.type !== undefined)  out.type  = schema.type;
+  if (schema.maxLength !== undefined) out.maxLength = schema.maxLength;
   if (Array.isArray(schema.enum)) out.enum  = [...schema.enum].sort();
   if (schema.items)               out.items = normalizeProperty(schema.items);
   if (schema.properties) {
@@ -116,5 +117,19 @@ describe("도구 계약 스냅샷", () => {
     const a  = normalizeToolContract(mk({ b: { type: "string" }, a: { type: "number" } }));
     const b  = normalizeToolContract(mk({ a: { type: "number" }, b: { type: "string" } }));
     assert.deepEqual(a, b);
+  });
+
+  test("정규화는 중첩 속성과 배열 항목의 문자열 길이 제한을 보존한다", () => {
+    const normalized = normalizeToolContract([{
+      name: "t",
+      inputSchema: { properties: {
+        agentId: { type: "string", maxLength: 128 },
+        batch: { type: "array", items: { type: "object", properties: {
+          id: { type: "string", maxLength: 0 }
+        } } }
+      } }
+    }]);
+    assert.equal(normalized.t.properties.agentId.maxLength, 128);
+    assert.equal(normalized.t.properties.batch.items.properties.id.maxLength, 0);
   });
 });

--- a/tests/unit/tool-meta.test.js
+++ b/tests/unit/tool-meta.test.js
@@ -127,6 +127,26 @@ describe("TOOL_REGISTRY — requiresMaster 제약 규칙", () => {
     assert.ok(entry.meta.capabilities.includes("admin"));
   });
 
+  it("check_update도 master에게만 노출된다", () => {
+    const entry = TOOL_REGISTRY.get("check_update");
+    assert.strictEqual(entry.meta.requiresMaster, true);
+    assert.ok(entry.meta.capabilities.includes("admin"));
+  });
+
+  it("memory_stats는 전역 집계이므로 requiresMaster=true다", () => {
+    const entry = TOOL_REGISTRY.get("memory_stats");
+    assert.strictEqual(entry.meta.requiresMaster, true);
+    assert.ok(entry.meta.capabilities.includes("admin"));
+  });
+
+});
+
+describe("TOOL_REGISTRY — audit log input safety", () => {
+  it("session_rotate 로그에 사용자 reason을 포함하지 않는다", () => {
+    const message = TOOL_REGISTRY.get("session_rotate").log({ reason: "synthetic\nforged" });
+    assert.equal(message, "Session rotated");
+    assert.doesNotMatch(message, /forged|\n/);
+  });
 });
 
 describe("TOOL_REGISTRY — 읽기 도구 안전성 규칙", () => {

--- a/tests/unit/topic-resolver.test.js
+++ b/tests/unit/topic-resolver.test.js
@@ -114,9 +114,27 @@ describe("suggestTopics", () => {
       "anchormind-mcp"
     );
 
-    assert.match(calls[0].sql, /key_id IS NOT DISTINCT FROM \$2/);
-    assert.match(calls[0].sql, /key_id = ANY\(\$3::text\[\]\)/);
-    assert.deepEqual(calls[0].params, ["anchormind-mcp", "key-1", ["key-1", "key-2"]]);
+    assert.match(calls[0].sql, /agent_id = \$2/);
+    assert.match(calls[0].sql, /key_id IS NOT DISTINCT FROM \$3/);
+    assert.match(calls[0].sql, /key_id = ANY\(\$4::text\[\]\)/);
+    assert.deepEqual(calls[0].params, ["anchormind-mcp", "default", "key-1", ["key-1", "key-2"]]);
+  });
+
+  it("peer topic 제안도 key/workspace 경계를 유지한다", async () => {
+    const { pool, calls } = stubPool([{ topic: "synthetic-topic-v2", count: 2 }]);
+
+    await suggestTopics(
+      { pool },
+      {
+        keyId: "key-a", groupKeyIds: ["key-a"], agentId: "agent-a",
+        includePeerAgents: true, _isMaster: true, workspace: "workspace-a"
+      },
+      "synthetic-topic"
+    );
+
+    assert.match(calls[0].sql, /peer-agent: no agent_id filter/);
+    assert.match(calls[0].sql, /key_id IS NOT DISTINCT FROM \$3/);
+    assert.match(calls[0].sql, /workspace = \$5/);
   });
 
   it("입력 topic의 형태소 벡터를 얻지 못하면 어휘 폴백으로 후보를 고른다", async () => {


### PR DESCRIPTION
## 요약

앵커와 후속 조회 경로에 `default` 공유 기억과 specific-agent 전용 기억의 범위를 일관되게 적용했습니다. `agentId`를 생략하면 공유 기억만, master가 specific agent를 지정하면 해당 agent와 공유 기억만 조회하며, 전체 agent 조회는 master의 명시적 `includePeerAgents=true` 요청으로 제한합니다.

원저자 검토를 반영해 변경을 다섯 개의 독립적인 논리 커밋으로 재구성하고, 스키마 확장·코드 롤링 배포·배치 backfill을 분리했습니다.

설계 및 수용 기준은 [포크 이슈 #3](https://github.com/itismyfield/anchormind/issues/3)에 정리했습니다.

## 커밋 구성

1. `db: add nullable agent scope snapshots and safe backfill`
2. `security: establish explicit master authentication context`
3. `security: enforce agent scope across memory reads`
4. `fix: harden session rotation and make Redis failure policy configurable`
5. `feat: add guarded legacy agent scope migration workflow`

각 커밋은 해당 범위의 타깃 테스트와 lint를 독립적으로 통과하도록 구성했습니다.

## 변경 사항

- anchor/core/learning/source/Working Memory/L1-L3/semantic/synthetic/graph/linked/stitch/CBR/history/trace에 공통 effective-agent scope를 적용했습니다.
- 일반 API key는 신뢰 가능한 agent identity binding이 없으므로 기본적으로 `default`만 허용합니다. specific agent와 peer 전체 조회는 인증된 master만 사용할 수 있습니다.
- 인증 결과의 `isMaster`를 세션·Redis·MCP·Legacy SSE·JSON-RPC 경로에 보존하고 내부 권한 필드 위조와 도구 discovery/실행 불일치를 차단했습니다.
- 링크 조회는 기존 OR 의미를 복원하면서 양 끝점의 agent/key/workspace 범위를 모두 검증합니다.
- session rotate에서 기존 mode/default workspace를 유지하고 requester identity를 재검증합니다.
- Redis 세션 저장 장애는 기본적으로 in-memory fallback을 유지합니다. `MEMENTO_REDIS_SESSION_FAIL_CLOSED=true`일 때만 요청을 실패시키며, 기존 Redis 세션 삭제 실패는 fixation 방지를 위해 계속 거부합니다.
- `case_events`와 `fragment_versions`에 nullable agent/workspace snapshot을 추가하고 신규 writer가 값을 기록합니다.
- `anchor-scope --backfill-snapshots`가 source가 남은 legacy snapshot을 짧은 배치로 복구하며, 처리 가능한 잔여 행이 있으면 비제로 종료합니다.
- source가 없거나 삭제된 legacy case event는 임의로 `default`에 귀속하지 않고 NULL 격리 상태를 유지하며 영향 건수를 진단 결과로 제공합니다.
- `anchor-scope --include-non-anchors`로 비앵커를 포함한 전체 legacy non-default 파편을 inventory하고, 승인 목록의 shared 항목만 `default`로 정규화할 수 있습니다.
- 즉시 이관이 어려운 경우 `MEMENTO_ALLOW_LEGACY_UNBOUND_AGENT_SCOPE=true`로 기존 동작을 임시 복원할 수 있으나 같은 key 내부 agent 격리가 보장되지 않음을 문서화했습니다.
- 중복된 기반 `case_events` 스키마 정의를 제거하고 rollback 스크립트를 추가했습니다.

## 마이그레이션 및 배포

1. additive·nullable migration-046 적용
2. 새 코드를 모든 인스턴스에 롤링 배포하고 구 writer 종료 확인
3. `anchor-scope --backfill-snapshots`로 영향 건수 사전 확인
4. `--backfill-snapshots --execute --approve-backfill`로 짧은 배치 backfill 실행
5. legacy non-default 파편을 분류한 뒤 승인된 shared 항목만 필요에 따라 이관

이번 PR에는 `NOT NULL` 강화를 포함하지 않습니다. 같은 릴리스에서 연속 적용하면 코드 배포 간격을 만들 수 없고, 읽기 경로가 NULL을 이미 fail-closed로 제외하기 때문입니다. 제약 강화가 필요하면 모든 writer와 backfill 전환이 끝난 후 별도 릴리스에서 다루는 것이 안전합니다.

## 테스트

- [x] `npm test` 통과 — 2,834건 통과, 실패 0건, 기존 skip 2건
- [x] `npm run test:integration` 통과 — 55건 통과, 실패 0건, 환경 조건에 따른 skip 5건
- [x] `npm run lint` 통과
- [x] `MIGRATION_LINT_FROM=46 npm run lint:migrations` 통과
- [x] 각 논리 커밋의 타깃 테스트와 import/lint 검증
- [x] PostgreSQL 17에서 migration 반복 적용, 구 writer INSERT, 불완전 backfill 실패, 재실행, rollback 검증
- [x] 최종 트리와 검토 완료 snapshot의 바이트 단위 동일성 확인

## 하위 호환성

- [x] nullable additive migration으로 구 writer 형식 유지
- [x] Redis 세션 저장 장애 시 기존 in-memory 가용성 기본값 유지
- [x] master specific-agent 조회와 명시적 peer 감사 경로 제공
- [x] 일반 API key의 임의 non-default `agentId`는 기본적으로 권한 오류
- [x] legacy 전체 파편의 승인 기반 이관 경로와 임시 호환 옵션 제공
- [ ] 소유 범위를 증명할 수 없는 legacy NULL snapshot은 non-peer 조회에서 제외될 수 있음
- [ ] master-only 도구는 일반 API key의 도구 목록에서 제외

검토에서 지적해 주신 배포 안전성, 데이터 가시성, 세션 가용성과 리뷰 단위 문제를 함께 보완했습니다. 다시 검토해 주시면 감사하겠습니다.
